### PR TITLE
Fix NullReferenceException of ConfirmationPopup and add description of Menuitem limitation

### DIFF
--- a/doc/guide/ConfirmationPopup.md
+++ b/doc/guide/ConfirmationPopup.md
@@ -13,6 +13,7 @@ summary: ConfirmationPopup control guide
 ## Create ConfirmationPopup
 `ConfirmationPopup.Title` Property sets the title of the popup. You can set the `Content` property with Layouts such as `StackLayout` or `ScrollView`.
 `ConfirmationPopup.FirstButton` property sets left side button. `ConfirmationPopup.SecondButton`property sets right side button. You can set` FirstButton` and `SecondButton` using `MenuItem`. You should add code at `Command` or `Clicked` event handler for controlling `MenuItem` clicked.
+*`Text` Property of `MenuItem` will be ignored since button has no spece to display text*
 
 _This guide's code example uses WearableUIGallery's TCConfirmationPopup code at the test\WearableUIGallery\WearableUIGallery\TC\TCConfirmationPopup.xaml.cs_
 

--- a/doc/guide/ConfirmationPopup.md
+++ b/doc/guide/ConfirmationPopup.md
@@ -13,7 +13,7 @@ summary: ConfirmationPopup control guide
 ## Create ConfirmationPopup
 `ConfirmationPopup.Title` Property sets the title of the popup. You can set the `Content` property with Layouts such as `StackLayout` or `ScrollView`.
 `ConfirmationPopup.FirstButton` property sets left side button. `ConfirmationPopup.SecondButton`property sets right side button. You can set` FirstButton` and `SecondButton` using `MenuItem`. You should add code at `Command` or `Clicked` event handler for controlling `MenuItem` clicked.
-*`Text` Property of `MenuItem` will be ignored since button has no spece to display text*
+*`Text` Property of `MenuItem` is ignored since button has no space to display text*
 
 _This guide's code example uses WearableUIGallery's TCConfirmationPopup code at the test\WearableUIGallery\WearableUIGallery\TC\TCConfirmationPopup.xaml.cs_
 

--- a/doc/guide/InformationPopup.md
+++ b/doc/guide/InformationPopup.md
@@ -36,6 +36,8 @@ For more information. Please refer to [InformationPopup  API reference](https://
 
 ## Create bottom button InformationPopup
 You can set `BottomButton` property with `MenuItem`. The bottom button is used for confirmation of user.
+Do not use `Icon` property and `Text` property at the same time because two area has the same position.
+You should use only one property between `Icon` property and `Text` property for avoiding overlapped.
 InformationPopup has `Title` property for displaying title.
 `BottomButton.Clicked` event occurs when user press bottom button.
 

--- a/doc/guide/TwoButtonPage.md
+++ b/doc/guide/TwoButtonPage.md
@@ -14,6 +14,7 @@ summary: TwoButtonPage control guide
 You can set control in the `TwoButtonPage.Content`. In this example, long text Label and two buttons were set for Content.
 If `Overlap` property is `true`, the `Content` area occupies the whole of the screen. If `Overlap` property is `false`, the `Content` area occupies screen that is excluded button's area. The default value of `Overlap` property is `false`.
 `TwoButtonPage.firstButton` sets left side button. `TwoButtonPage.SecondButton` sets right side button. You can add buttons using `MenuItem`.
+*`Text` Property of `MenuItem` is ignored since button has no space to display text*
 
 _This guide's code example uses WearableUIGallery's TCTwoButtonPage code at the test\WearableUIGallery\WearableUIGallery\TC\TCTwoButtonPage.xaml_
 

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/ConfirmationPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/ConfirmationPopupImplementation.cs
@@ -258,7 +258,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
                 if (!string.IsNullOrEmpty(SecondButton.Text)) _secondButton.Text = SecondButton.Text;
 
-                if (FirstButton.Icon != null)
+                if (SecondButton.Icon != null)
                 {
                     var iconPath = SecondButton.Icon.File;
                     if (!string.IsNullOrEmpty(iconPath))

--- a/src/Tizen.Wearable.CircularUI.Forms/ConfirmationPopup.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/ConfirmationPopup.cs
@@ -158,6 +158,7 @@ namespace Tizen.Wearable.CircularUI.Forms
 
         /// <summary>
         /// Gets or sets left button of the Popup.
+        /// Text property of MenuItem is ignored since button has no space to display text.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public MenuItem FirstButton
@@ -168,6 +169,7 @@ namespace Tizen.Wearable.CircularUI.Forms
 
         /// <summary>
         /// Gets or sets right button of the Popup.
+        /// Text property of MenuItem is ignored since button has no space to display text.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public MenuItem SecondButton

--- a/src/Tizen.Wearable.CircularUI.Forms/InformationPopup.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/InformationPopup.cs
@@ -103,6 +103,7 @@ namespace Tizen.Wearable.CircularUI.Forms
 
         /// <summary>
         /// Gets or sets bottom button of the Popup.
+        /// You should use only one property between `Icon` property and `Text` property because two area has the same position.
         /// </summary>
         public MenuItem BottomButton
         {

--- a/src/Tizen.Wearable.CircularUI.Forms/TwoButtonPage.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/TwoButtonPage.cs
@@ -62,6 +62,7 @@ namespace Tizen.Wearable.CircularUI.Forms
 
         /// <summary>
         /// Gets or sets left button of TwoButtonPage
+        /// Text property of MenuItem is ignored since button has no space to display text.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public MenuItem FirstButton
@@ -71,6 +72,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         }
         /// <summary>
         /// Gets or sets right button of TwoButtonPage
+        /// Text property of MenuItem is ignored since button has no space to display text.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public MenuItem SecondButton


### PR DESCRIPTION
### Description of Change ###
- Fix NullReferenceException of ConfirmationPopup
- add description of Menuitem on each Popup.


### Bugs Fixed ###
- If confirmationPopup second menuitem has no icon , it will make NullReferenceException.

### API Changes ###
N/A


### Behavioral Changes ###
N/A
