### PR TITLE
Rename from ConfirmationPopup to TwoButtonPopup at sample app

### DIFF
--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleText2Button.cs
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleText2Button.cs
@@ -4,7 +4,7 @@ using Tizen.Wearable.CircularUI.Forms;
 
 namespace UIComponents.Samples.Popup
 {
-    public class TitleText2Button : ConfirmationPopup
+    public class TitleText2Button : TwoButtonPopup
     {
         public TitleText2Button()
         {

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleTextCheckButton.cs
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleTextCheckButton.cs
@@ -5,7 +5,7 @@ using WCheck = Tizen.Wearable.CircularUI.Forms.Check;
 
 namespace UIComponents.Samples.Popup
 {
-    public class TitleTextCheckButton : ConfirmationPopup
+    public class TitleTextCheckButton : TwoButtonPopup
     {
         public TitleTextCheckButton()
         {

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/PopupList.xaml.cs
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/PopupList.xaml.cs
@@ -27,7 +27,7 @@ namespace UIComponents.Samples
                 if (title.EndsWith("2button"))
                 {
                     Console.WriteLine($"title end 2button ");
-                    var twoButtonPopup = Activator.CreateInstance(pageType) as ConfirmationPopup;
+                    var twoButtonPopup = Activator.CreateInstance(pageType) as TwoButtonPopup;
                     if (twoButtonPopup != null) twoButtonPopup.Show();
                 }
                 else if (title.Equals("Toast"))

--- a/sample/XUIComponents/UIComponents/UIComponents/UIComponents.csproj
+++ b/sample/XUIComponents/UIComponents/UIComponents/UIComponents.csproj
@@ -6,7 +6,7 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.0.0-pre2-00012" />
+    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.0.0-pre2-00020" />
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change ###
Rename from ConfirmationPopup to TwoButtonPopup at sample app

### Bugs Fixed ###
N/A

### API Changes ###
N/A

### Behavioral Changes ###
N/A
