### PR TITLE
Fix CirclePage to applies modified BindingContext

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms/CirclePage.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CirclePage.cs
@@ -115,6 +115,17 @@ namespace Tizen.Wearable.CircularUI.Forms
             set => SetValue(RotaryFocusTargetNameProperty, value);
         }
 
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+            foreach (var item in CircleSurfaceItems)
+            {
+                var element = item as Element;
+                if (element != null)
+                    SetInheritedBindingContext(element, BindingContext);
+            }
+        }
+
         void OnSurfaceItemsChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
             if (args.Action != NotifyCollectionChangedAction.Add) return;


### PR DESCRIPTION
Applies the modified BindingContext to CircleSurfaceItems.

### Description of Change ###
Now modified BindingContext will be set to the children of CircleSurfaceItems on BindingContext is changed.


### Bugs Fixed ###
- Even though the BindingContext has changed, it has not been applied to CircleSurfaceItems.


### API Changes ###
-

 ### Behavioral Changes ###
Every child in CircleSurfaceItems will be set modified BindingContext after CirclePage.BindingContext is changed.
