### PR TITLE
Change CircleSlider MaxValue to 11

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms/CircleSliderSurfaceItem.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleSliderSurfaceItem.cs
@@ -40,7 +40,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         /// BindableProperty. Identifies the Maximum bindable property.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(CircleSliderSurfaceItem), 1d, coerceValue: (bindable, value) =>
+        public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(CircleSliderSurfaceItem), 11d, coerceValue: (bindable, value) =>
         {
             var slider = (CircleSliderSurfaceItem)bindable;
             slider.Value = slider.Value.Clamp(slider.Minimum, (double)value);


### PR DESCRIPTION
### Description of Change ###
Change CircleSlider MaxValue to 11
Since the existing default minimum / maximum value is 0 to 1 and the amount of change is 1, the amount of change is not seen, so the default value is changed.


### Bugs Fixed ###
-


### API Changes ###
Changed:
 - change default value of CircleSliderSurfaceItem.MaximumProperty to 11.

### Behavioral Changes ###
