### PR TITLE
Remove RotaryFocusTargetName at XUIComponents sample

### DIFF
--- a/sample/XUIComponents/UIComponents/UIComponents/App.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/App.xaml
@@ -8,7 +8,7 @@
     <Application.MainPage>
         <NavigationPage x:Name="MainNavigation">
             <x:Arguments>
-                <w:CirclePage NavigationPage.HasNavigationBar="False" RotaryFocusTargetName="MainList">
+                <w:CirclePage NavigationPage.HasNavigationBar="False" RotaryFocusObject="{x:Reference MainList}">
                     <w:CirclePage.BindingContext>
                         <local:AppViewModel />
                     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/BackgroundList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/BackgroundList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="bglist">
+    RotaryFocusObject="{x:Reference bglist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Button/DefaultButton.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Button/DefaultButton.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.Button"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="myscroller">
+    RotaryFocusObject="{x:Reference myscroller}">
     <w:CirclePage.Content>
         <w:CircleScrollView x:Name="myscroller" Orientation="Vertical">
             <StackLayout Padding="0,30" Orientation="Vertical">

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/ButtonList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/ButtonList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="buttonlist">
+    RotaryFocusObject="{x:Reference buttonlist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTime/CircleDate.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTime/CircleDate.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleDateTime"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="dateSelector">
+    RotaryFocusObject="{x:Reference dateSelector}">
     <w:CirclePage.BindingContext>
         <local:DateTimeViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTime/CircleTime.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTime/CircleTime.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleDateTime"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="timeSelector">
+    RotaryFocusObject="{x:Reference timeSelector}">
     <w:CirclePage.BindingContext>
         <local:DateTimeViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTimeList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleDateTimeList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="dateTimeList">
+    RotaryFocusObject="{x:Reference dateTimeList}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleGenList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleGenList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="genlist">
+    RotaryFocusObject="{x:Reference genlist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text1Icon.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text1Icon.xaml
@@ -5,12 +5,15 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
-        <w:CircleListView x:Name="mylist" ItemsSource="{Binding Names}">
+        <w:CircleListView
+            x:Name="mylist"
+            HasUnevenRows="True"
+            ItemsSource="{Binding Names}">
             <w:CircleListView.ItemTemplate>
                 <DataTemplate>
                     <ViewCell>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text1Icon1.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1Text1Icon1.xaml
@@ -5,12 +5,15 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
-        <w:CircleListView x:Name="mylist" ItemsSource="{Binding Names}">
+        <w:CircleListView
+            x:Name="mylist"
+            HasUnevenRows="True"
+            ItemsSource="{Binding Names}">
             <w:CircleListView.ItemTemplate>
                 <DataTemplate>
                     <ViewCell>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1text1iconDivider.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style1text1iconDivider.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1icon.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1icon.xaml
@@ -5,12 +5,15 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
-        <w:CircleListView x:Name="mylist" ItemsSource="{Binding Names}">
+        <w:CircleListView
+            x:Name="mylist"
+            HasUnevenRows="True"
+            ItemsSource="{Binding Names}">
             <w:CircleListView.ItemTemplate>
                 <DataTemplate>
                     <ViewCell>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1icon1.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1icon1.xaml
@@ -5,12 +5,15 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
-        <w:CircleListView x:Name="mylist" ItemsSource="{Binding Names}">
+        <w:CircleListView
+            x:Name="mylist"
+            HasUnevenRows="True"
+            ItemsSource="{Binding Names}">
             <w:CircleListView.ItemTemplate>
                 <DataTemplate>
                     <ViewCell>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1iconDivider.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style2text1iconDivider.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style3text.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style3text.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style4text.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/Style4text.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleMultiline.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleMultiline.xaml
@@ -6,12 +6,15 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
-        <w:CircleListView x:Name="mylist" ItemsSource="{Binding LongTexts}" HasUnevenRows ="True">
+        <w:CircleListView
+            x:Name="mylist"
+            HasUnevenRows="True"
+            ItemsSource="{Binding LongTexts}">
             <w:CircleListView.ItemTemplate>
                 <DataTemplate>
                     <ex:MultilineCell Text="{Binding ., StringFormat='elm.text:{0}'}" />

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleSelectMode.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleSelectMode.xaml
@@ -1,40 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<w:CirclePage xmlns="http://xamarin.com/schemas/2014/forms"
-              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-              xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
-              xmlns:effect="clr-namespace:UIComponents.Extensions.Effects"
-              xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-              x:Class="UIComponents.Samples.CircleList.StyleSelectMode" x:Name="Control">
+<w:CirclePage
+    x:Class="UIComponents.Samples.CircleList.StyleSelectMode"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:effect="clr-namespace:UIComponents.Extensions.Effects"
+    xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
+    x:Name="Control">
     <w:CirclePage.BindingContext>
         <local:ListViewModel x:Name="ListModel" />
     </w:CirclePage.BindingContext>
     <w:CirclePage.Content>
         <AbsoluteLayout>
-            <w:CircleListView ItemsSource="{Binding CheckableNames}" x:Name="MyList"
-                              AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
-                              AbsoluteLayout.LayoutFlags="All"
-                              effect:ItemLongPressEffect.Command="{Binding LongClickCommand, Source={x:Reference Control}}">
+            <w:CircleListView
+                x:Name="MyList"
+                effect:ItemLongPressEffect.Command="{Binding LongClickCommand, Source={x:Reference Control}}"
+                AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
+                AbsoluteLayout.LayoutFlags="All"
+                ItemsSource="{Binding CheckableNames}">
                 <w:CircleListView.Effects>
-                    <effect:ItemLongPressEffect/>
+                    <effect:ItemLongPressEffect />
                 </w:CircleListView.Effects>
                 <w:CircleListView.ItemTemplate>
                     <DataTemplate>
                         <ViewCell>
                             <AbsoluteLayout HeightRequest="80">
-                                <Label Text="{Binding Name}"
-                                       HorizontalTextAlignment="Center"
-                                       VerticalTextAlignment="Center"
-                                       FontSize="Large"
-                                       AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
-                                       AbsoluteLayout.LayoutFlags="All"/>
-                                <w:Check DisplayStyle="Default" IsToggled="{Binding Checked, Mode=TwoWay}" IsEnabled="{Binding IsCheckable, Source={x:Reference Control}}"
-                                         AbsoluteLayout.LayoutBounds="0.5, 0.5, AutoSize, AutoSize"
-                                         AbsoluteLayout.LayoutFlags="PositionProportional"
-                                         effect:TizenStyleEffect.Style="genlist/select_mode"
-                                         effect:TizenEventPropagationEffect.EnablePropagation="True">
+                                <Label
+                                    AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
+                                    AbsoluteLayout.LayoutFlags="All"
+                                    FontSize="Large"
+                                    HorizontalTextAlignment="Center"
+                                    Text="{Binding Name}"
+                                    VerticalTextAlignment="Center" />
+                                <w:Check
+                                    effect:TizenEventPropagationEffect.EnablePropagation="True"
+                                    effect:TizenStyleEffect.Style="genlist/select_mode"
+                                    AbsoluteLayout.LayoutBounds="0.5, 0.5, AutoSize, AutoSize"
+                                    AbsoluteLayout.LayoutFlags="PositionProportional"
+                                    DisplayStyle="Default"
+                                    IsEnabled="{Binding IsCheckable, Source={x:Reference Control}}"
+                                    IsToggled="{Binding Checked, Mode=TwoWay}">
                                     <w:Check.Effects>
-                                        <effect:TizenStyleEffect/>
-                                        <effect:TizenEventPropagationEffect/>
+                                        <effect:TizenStyleEffect />
+                                        <effect:TizenEventPropagationEffect />
                                     </w:Check.Effects>
                                 </w:Check>
                             </AbsoluteLayout>
@@ -42,23 +50,21 @@
                     </DataTemplate>
                 </w:CircleListView.ItemTemplate>
             </w:CircleListView>
-            <Button x:Name="CheckedCounter"
-                    IsVisible="{Binding IsCheckable, Source={x:Reference Control}}"
-                    Text="{Binding CheckedNamesCount, StringFormat='{0:D2}'}"
-                    AbsoluteLayout.LayoutBounds="0.5, 10, AUtoSize, AutoSize"
-                    AbsoluteLayout.LayoutFlags="XProportional"
-                    effect:TizenStyleEffect.Style="select_mode"
-                    Clicked="OnCheckedCounterClicked">
-                <Button.Effects>
-                    <w:ConfirmPopupEffect/>
-                </Button.Effects>
+            <Button
+                x:Name="CheckedCounter"
+                effect:TizenStyleEffect.Style="select_mode"
+                AbsoluteLayout.LayoutBounds="0.5, 10, AUtoSize, AutoSize"
+                AbsoluteLayout.LayoutFlags="XProportional"
+                Clicked="OnCheckedCounterClicked"
+                IsVisible="{Binding IsCheckable, Source={x:Reference Control}}"
+                Text="{Binding CheckedNamesCount, StringFormat='{0:D2}'}">
                 <Button.Behaviors>
                     <w:ContextPopupEffectBehavior
-                        AcceptText="{Binding SelectOptionMessage1, Source={x:Reference ListModel}}"
                         AcceptCommand="{Binding SelectCommand1, Source={x:Reference ListModel}}"
-                        CancelText="{Binding SelectOptionMessage2, Source={x:Reference ListModel}}"
+                        AcceptText="{Binding SelectOptionMessage1, Source={x:Reference ListModel}}"
                         CancelCommand="{Binding SelectCommand2, Source={x:Reference ListModel}}"
-                        Visibility="{Binding PopupVisibility, Source={x:Reference Control}, Mode=TwoWay}"/>
+                        CancelText="{Binding SelectOptionMessage2, Source={x:Reference ListModel}}"
+                        Visibility="{Binding PopupVisibility, Source={x:Reference Control}, Mode=TwoWay}" />
                 </Button.Behaviors>
             </Button>
         </AbsoluteLayout>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleTitle.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleTitle.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleTitleGroupIndex.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleList/StyleTitleGroupIndex.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleList"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="mylist">
+    RotaryFocusObject="{x:Reference mylist}">
     <w:CirclePage.BindingContext>
         <local:ListVieGroupModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScroller/HorizontalScroller.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScroller/HorizontalScroller.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleScroller"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="myscroller">
+    RotaryFocusObject="{x:Reference myscroller}">
     <w:CirclePage.Content>
         <w:CircleScrollView x:Name="myscroller" Orientation="Horizontal">
             <StackLayout

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScroller/VerticalScroller.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScroller/VerticalScroller.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleScroller"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="myscroller">
+    RotaryFocusObject="{x:Reference myscroller}">
     <w:CirclePage.Content>
         <w:CircleScrollView x:Name="myscroller" Orientation="Vertical">
             <StackLayout

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScrollerList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleScrollerList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="scrollerList">
+    RotaryFocusObject="{x:Reference scrollerList}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSlider.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSlider.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="slider">
+    RotaryFocusObject="{x:Reference slider}">
     <w:CirclePage.Content>
         <StackLayout
             HorizontalOptions="Center"

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerDefault.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerDefault.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleSpinner"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="stepper">
+    RotaryFocusObject="{x:Reference stepper}">
     <w:CirclePage.BindingContext>
         <local:SpinnerViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerTimer.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerTimer.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples.CircleSpinner"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="StepperHr3">
+    RotaryFocusObject="{x:Reference StepperHr3}">
     <w:CirclePage.BindingContext>
         <local:SpinnerViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerTimer.xaml.cs
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinner/SpinnerTimer.xaml.cs
@@ -14,15 +14,15 @@ namespace UIComponents.Samples.CircleSpinner
 
         void OnFocusedHr(object sender, ValueChangedEventArgs args)
         {
-            RotaryFocusTargetName = "StepperHr3";
+            RotaryFocusObject = StepperHr3;
         }
         void OnFocusedMm(object sender, ValueChangedEventArgs args)
         {
-            RotaryFocusTargetName = "StepperMm3";
+            RotaryFocusObject = StepperMm3;
         }
         void OnFocusedSec(object sender, ValueChangedEventArgs args)
         {
-            RotaryFocusTargetName = "StepperSec3";
+            RotaryFocusObject = StepperSec3;
         }
     }
 }

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinnerList .xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/CircleSpinnerList .xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="spinnerList">
+    RotaryFocusObject="{x:Reference spinnerList}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/EntryList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/EntryList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="entrylist">
+    RotaryFocusObject="{x:Reference entrylist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Image.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Image.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="myscroller">
+    RotaryFocusObject="{x:Reference myscroller}">
     <w:CirclePage.Content>
         <w:CircleScrollView x:Name="myscroller" Orientation="Vertical">
             <StackLayout Padding="50,50" Orientation="Vertical">

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/NoContentList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/NoContentList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="nocontentlist">
+    RotaryFocusObject="{x:Reference nocontentlist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/PageControlList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/PageControlList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="pageControlList">
+    RotaryFocusObject="{x:Reference pageControlList}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleTextCheckButton.cs
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Popup/TitleTextCheckButton.cs
@@ -59,7 +59,7 @@ namespace UIComponents.Samples.Popup
                     new StackLayout
                     {
                         Orientation = StackOrientation.Horizontal,
-                        Padding = new Thickness(0, 30, 0, 30),
+                        Padding = new Thickness(0, 40, 0, 40),
                         Children =
                         {
                             checkbox,

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/PopupList.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/PopupList.xaml
@@ -6,7 +6,7 @@
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
     NavigationPage.HasNavigationBar="False"
-    RotaryFocusTargetName="popuplist">
+    RotaryFocusObject="{x:Reference popuplist}">
     <w:CirclePage.BindingContext>
         <local:AppViewModel />
     </w:CirclePage.BindingContext>

--- a/sample/XUIComponents/UIComponents/UIComponents/Samples/Radio.xaml
+++ b/sample/XUIComponents/UIComponents/UIComponents/Samples/Radio.xaml
@@ -5,7 +5,7 @@
     xmlns:local="clr-namespace:UIComponents.Samples"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
     xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-    RotaryFocusTargetName="myscroller">
+    RotaryFocusObject="{x:Reference myscroller}">
     <w:CirclePage.Content>
         <w:CircleScrollView x:Name="myscroller" Orientation="Vertical">
             <StackLayout Padding="50,50" Orientation="Vertical">

--- a/sample/XUIComponents/UIComponents/UIComponents/UIComponents.csproj
+++ b/sample/XUIComponents/UIComponents/UIComponents/UIComponents.csproj
@@ -6,8 +6,8 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.0.0-pre2-00028" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.0.0-pre2-00042" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.583944" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change ###
- remove RotaryFocusTargetName and replace to RotaryFocusObject
- fix check Icon selecting issue when scroll up genlist. (add HasUnEvenRow)

### Bugs Fixed ###
- fix check Icon selecting issue when scroll up genlist. (add HasUnEvenRow)

### API Changes ###
N/A

### Behavioral Changes ###
N/A
