### PR TITLE
Change Dismiss() from hide popup to dimiss and remove all resources 

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
@@ -52,6 +52,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _popUp.SetContent(_layout);
 
             _popUp.BackButtonPressed += BackButtonPressedHandler;
+            _popUp.Dismissed += OnDismissed;
         }
 
         ~InformationPopupImplementation()
@@ -187,14 +188,31 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 _box.PackEnd(_progress);
 
                 _layout.SetPartContent("elm.swallow.content", _box, true);
-
-                UpdateTitle();
-                UpdateText();
             }
             else
             {
+                if (_box != null)
+                {
+                    if (_progress != null)
+                    {
+                        _progress.Unrealize();
+                        _progress = null;
+                    }
+
+                    if (_progressLabel != null)
+                    {
+                        _progressLabel.Unrealize();
+                        _progressLabel = null;
+                    }
+
+                    _box.Unrealize();
+                    _box = null;
+                }
                 _layout.SetPartContent("elm.swallow.content", null, true);
             }
+
+            UpdateTitle();
+            UpdateText();
         }
 
         void UpdateButton()
@@ -284,12 +302,23 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 throw new Exception("When the Application's Platform is null, can not show the Dialog.");
             }
 
-            _popUp.Show();
+            if (_popUp != null)
+            {
+                _popUp.Show();
+            }
         }
 
         public void Dismiss()
         {
-            _popUp.Hide();
+            if (_popUp != null)
+            {
+                _popUp.Dismiss();
+            }
+        }
+
+        void OnDismissed(object sender, EventArgs e)
+        {
+            Dispose();
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/ToastImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/ToastImplementation.cs
@@ -47,6 +47,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _control.BackButtonPressed += (s, e) => _control.Dismiss();
             _control.TimedOut += (s, e) => _control.Dismiss();
             _control.OutsideClicked += (s, e) => _control.Dismiss();
+            _control.Dismissed += OnDismissed;
 
             UpdateIcon();
             UpdateText();
@@ -150,6 +151,11 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         public void Dismiss()
         {
             _control.Dismiss();
+        }
+
+        void OnDismissed(object sender, EventArgs e)
+        {
+            Dispose();
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
@@ -53,6 +53,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _popUp.SetContent(_layout);
 
             _popUp.BackButtonPressed += BackButtonPressedHandler;
+            _popUp.Dismissed += OnDismissed;
 
             _contentView = new StackLayout();
         }
@@ -80,6 +81,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                     _firstButton.Unrealize();
                     _firstButton = null;
                 }
+
                 if (_secondButton != null)
                 {
                     _secondButton.Unrealize();
@@ -274,13 +276,24 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 {
                     SecondButton.Activate();
                 };
+
+                _popUp.SetPartContent("button2", _secondButton);
             }
             else
             {
+                /* This is workaround fix for Left button occupied whole window when right button is null*/
+                _secondButton = new ElmSharp.Button(_popUp)
+                {
+                    WeightX = 1.0,
+                    WeightY = 1.0,
+                    Style = "popup/circle/right"
+                };
+                _popUp.SetPartContent("button2", _secondButton);
+                _secondButton.Unrealize();
                 _secondButton = null;
             }
 
-            _popUp.SetPartContent("button2", _secondButton);
+           // _popUp.SetPartContent("button2", _secondButton);
         }
 
         void UpdateTitle()
@@ -303,12 +316,24 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             {
                 UpdateContent();
             }
-            _popUp.Show();
+
+            if (_popUp != null)
+            {
+                _popUp.Show();
+            }
         }
 
         public void Dismiss()
         {
-            _popUp.Hide();
+            if (_popUp != null)
+            {
+                _popUp.Dismiss();
+            }
+        }
+
+        void OnDismissed(object sender, EventArgs e)
+        {
+            Dispose();
         }
     }
 }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
@@ -35,18 +35,11 @@ namespace WearableUIGallery.TC
         MenuItem _textBottomButton;
         MenuItem _iconBottomButton;
         MenuItem _textIconBottomButton;
+        string _longText;
 
         public TCInformationPopup()
         {
             InitializeComponent();
-
-            _textPopUp = new InformationPopup();
-
-            _textPopUp.BackButtonPressed += (s, e) =>
-            {
-                _textPopUp.Dismiss();
-                label1.Text = "text popup is dismissed";
-            };
 
             _textBottomButton = new MenuItem()
             {
@@ -54,7 +47,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("text bottom button Command!!");
-                    _textButtonPopUp.Dismiss();
+                    _textButtonPopUp?.Dismiss();
+                    _textButtonPopUp = null;
                 })
             };
 
@@ -67,7 +61,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("icon bottom button Command!!");
-                    _textButtonPopUp.Dismiss();
+                    _textButtonPopUp?.Dismiss();
+                    _textButtonPopUp = null;
                 })
             };
 
@@ -81,10 +76,32 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("text&icon bottom button Command!!");
-                    _textButtonPopUp.Dismiss();
+                    _textButtonPopUp?.Dismiss();
+                    _textButtonPopUp = null;
                 })
             };
 
+            _longText = @"This is scrollable popup text.
+This part is made by adding long text in popup.Popup internally added
+scroller to this layout when size of text is greater than total popup
+height.This has two button in action area and title text in title area";
+        }
+
+        void createTextPopup()
+        {
+            _textPopUp = new InformationPopup();
+
+            _textPopUp.BackButtonPressed += (s, e) =>
+            {
+                _textPopUp?.Dismiss();
+                _textPopUp = null;
+                label1.Text = "text popup is dismissed";
+            };
+
+        }
+
+        void createTextButtonPopup()
+        {
             _textButtonPopUp = new InformationPopup();
             _textButtonPopUp.Title = "Popup title";
             _textButtonPopUp.Text = "This is text and button popup test";
@@ -92,16 +109,21 @@ namespace WearableUIGallery.TC
 
             _textButtonPopUp.BackButtonPressed += (s, e) =>
             {
-                _textButtonPopUp.Dismiss();
+                _textButtonPopUp?.Dismiss();
+                _textButtonPopUp = null;
                 label1.Text = "text&button is dismissed";
             };
 
             _textButtonPopUp.BottomButton.Clicked += (s, e) =>
             {
-                _textButtonPopUp.Dismiss();
+                _textButtonPopUp?.Dismiss();
+                _textButtonPopUp = null;
                 label1.Text = "text&button is dismissed";
             };
+        }
 
+        void createProgressPopup()
+        {
             _progressPopUp = new InformationPopup();
             _progressPopUp.Title = "Popup title";
             _progressPopUp.Text = "This is progress test";
@@ -109,46 +131,45 @@ namespace WearableUIGallery.TC
 
             _progressPopUp.BackButtonPressed += (s, e) =>
             {
-                _progressPopUp.Dismiss();
+                _progressPopUp?.Dismiss();
+                _progressPopUp = null;
                 label1.Text = "progress is dismissed";
             };
-
         }
 
         private void OnTextButtonClicked(object sender, EventArgs e)
         {
+            createTextPopup();
             _textPopUp.Text = "This is text popup test";
+
             _textPopUp.Show();
         }
 
         private void OnLongTextButtonClicked(object sender, EventArgs e)
         {
-            _textPopUp.Text = @"This is scrollable popup text.
-This part is made by adding long text in popup.Popup internally added
-scroller to this layout when size of text is greater than total popup
-height.This has two button in action area and title text in title area";
-
+            createTextPopup();
+            _textPopUp.Text = _longText;
             _textPopUp.Show();
         }
 
         private void OnTitleTextButtonClicked(object sender, EventArgs e)
         {
+            createTextButtonPopup();
             _textButtonPopUp.Text = "This is text and button popup test";
             _textButtonPopUp.BottomButton = _textBottomButton;
             _textButtonPopUp.Show();
         }
         private void OnIconBottomButtonClicked(object sender, EventArgs e)
         {
-            _textButtonPopUp.Text = @"This is scrollable popup text.
-This part is made by adding long text in popup.Popup internally added
-scroller to this layout when size of text is greater than total popup
-height.This has two button in action area and title text in title area";
+            createTextButtonPopup();
+            _textButtonPopUp.Text = _longText;
             _textButtonPopUp.BottomButton = _iconBottomButton;
             _textButtonPopUp.Show();
         }
 
         private void OnIconAndTextBottomButtonClicked(object sender, EventArgs e)
         {
+            createTextButtonPopup();
             _textButtonPopUp.Text = "This is text and button popup test";
             _textButtonPopUp.BottomButton = _textIconBottomButton;
             _textButtonPopUp.Show();
@@ -156,14 +177,15 @@ height.This has two button in action area and title text in title area";
 
         private void OnProcessButtonClicked(object sender, EventArgs e)
         {
+            createProgressPopup();
             _progressPopUp.Show();
 
             Device.StartTimer(TimeSpan.FromMilliseconds(3000), () =>
             {
-                _progressPopUp.SetValue(InformationPopup.IsProgressRunningProperty, false);
-                _progressPopUp.SetValue(InformationPopup.TitleProperty, "Stopped Popup");
-                _progressPopUp.SetValue(InformationPopup.TextProperty, "Progress is finished");
-                _progressPopUp.SetValue(InformationPopup.BottomButtonProperty, new MenuItem
+                _progressPopUp?.SetValue(InformationPopup.TitleProperty, "Stopped Popup");
+                _progressPopUp?.SetValue(InformationPopup.TextProperty, "Progress is finished");
+                _progressPopUp?.SetValue(InformationPopup.IsProgressRunningProperty, false);
+                _progressPopUp?.SetValue(InformationPopup.BottomButtonProperty, new MenuItem
                 {
                     Text = "Reset",
                     Command = new Command(() => {
@@ -179,6 +201,7 @@ height.This has two button in action area and title text in title area";
 
         private void OnProcessLongTextButtonClicked(object sender, EventArgs e)
         {
+            createProgressPopup();
             _progressPopUp.Text = @"This is scrollable popup text.
 This part is made by adding long text in popup.Popup internally added
 scroller to this layout when size of text is greater than total popup

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
@@ -29,7 +29,7 @@ namespace WearableUIGallery.TC
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class TCTwoButtonPopup : ContentPage
     {
-        StackLayout _content ;
+        StackLayout _content;
         TwoButtonPopup _popUp1;
         TwoButtonPopup _popUp2;
         TwoButtonPopup _popUp3;
@@ -39,6 +39,7 @@ namespace WearableUIGallery.TC
         MenuItem _noIconRightButton;
         MenuItem _jpgIconButton1;
         MenuItem _jpgIconButton2;
+        string _longText;
 
         public TCTwoButtonPopup()
         {
@@ -53,7 +54,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("left button1 Command!!");
-                    _popUp1.Dismiss();
+                    _popUp1?.Dismiss();
+                    _popUp1 = null;
                 })
             };
 
@@ -66,7 +68,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("right button1 Command!!");
-                    _popUp1.Dismiss();
+                    _popUp1?.Dismiss();
+                    _popUp1 = null;
                 })
             };
 
@@ -76,7 +79,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("No icon left button Command!!");
-                    _popUp1.Dismiss();
+                    _popUp1?.Dismiss();
+                    _popUp1 = null;
                 })
             };
 
@@ -86,35 +90,49 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("no icon right button Command!!");
-                    _popUp1.Dismiss();
+                    _popUp1?.Dismiss();
+                    _popUp1 = null;
                 })
             };
 
-            _jpgIconButton1 = new MenuItem()
+            _content = new StackLayout()
             {
-                Icon = new FileImageSource
+                HorizontalOptions = LayoutOptions.FillAndExpand,
+                Children =
                 {
-                    File = "image/a.jpg",
-                },
-                Command = new Command(() =>
-                {
-                    Console.WriteLine("jpg button1 Command!!");
-                    _popUp3.Dismiss();
-                })
+                    new Label
+                    {
+                        Text = "This is Label of Content area on Two button Popup.",
+                        TextColor = Color.LightSkyBlue,
+                    },
+                    new StackLayout
+                    {
+                        Orientation = StackOrientation.Horizontal,
+                        Padding = new Thickness(0, 40, 0, 40),
+                        Children =
+                        {
+                            new Check
+                            {
+                                DisplayStyle = CheckDisplayStyle.Small
+                            },
+                            new Label
+                            {
+                                Text = "Do not repeat",
+                            }
+                        }
+                    }
+                }
             };
 
-            _jpgIconButton2 = new MenuItem()
-            {
-                Icon = new FileImageSource
-                {
-                    File = "image/b.jpg",
-                },
-                Command = new Command(() =>
-                {
-                    Console.WriteLine("jpg button2 Command!!");
-                    _popUp3.Dismiss();
-                })
-            };
+            _longText = @"This is scrollable popup text.
+This part is made by adding long text in popup. Popup internally added
+scroller to this layout when size of text is greater than total popup
+height. This has two button in action area and title text in title area";
+
+        }
+
+        void createPopup1()
+        {
 
 
             var checkbox = new Check
@@ -158,10 +176,17 @@ namespace WearableUIGallery.TC
 
             _popUp1.BackButtonPressed += (s, e) =>
             {
-                _popUp1.Dismiss();
+                _popUp1?.Dismiss();
+                _popUp1 = null;
                 label1.Text = "Popup1 is dismissed";
             };
 
+            _popUp1.FirstButton.Clicked += (s, e) => Console.WriteLine("First(share) button clicked!");
+            _popUp1.SecondButton.Clicked += (s, e) => Console.WriteLine("Second(delete) button clicked!");
+        }
+
+        void createPopup2()
+        {
             var leftButton2 = new MenuItem()
             {
                 Icon = new FileImageSource
@@ -171,7 +196,8 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("left button2 Command!!");
-                    _popUp2.Dismiss();
+                    _popUp2?.Dismiss();
+                    _popUp2 = null;
                 })
             };
 
@@ -184,50 +210,58 @@ namespace WearableUIGallery.TC
                 Command = new Command(() =>
                 {
                     Console.WriteLine("right button2 Command!!");
-                    _popUp2.Dismiss();
+                    _popUp2?.Dismiss();
+                    _popUp2 = null;
                 })
             };
 
             _popUp2 = new TwoButtonPopup();
-            _popUp2.Title= "Popup title";
-            _popUp2.Text = @"This is scrollable popup text.
-This part is made by adding long text in popup. Popup internally added
-scroller to this layout when size of text is greater than total popup
-height. This has two button in action area and title text in title area";
+            _popUp2.Title = "Popup title";
+            _popUp2.Text = _longText;
             _popUp2.SetValue(TwoButtonPopup.FirstButtonProperty, leftButton2);
             _popUp2.SetValue(TwoButtonPopup.SecondButtonProperty, rightButton2);
 
             _popUp2.BackButtonPressed += (s, e) =>
             {
-                _popUp2.Dismiss();
+                _popUp2?.Dismiss();
+                _popUp2 = null;
                 label1.Text = "Popup2 is dismissed";
             };
 
+            _popUp2.FirstButton.Clicked += (s, e) => Console.WriteLine("_popUp2 First button clicked!");
+            _popUp2.SecondButton.Clicked += (s, e) => Console.WriteLine("_popUp2 Second button clicked!");
+        }
 
-
-            _content = new StackLayout()
+        void createPopup3()
+        {
+            _jpgIconButton1 = new MenuItem()
             {
-                HorizontalOptions = LayoutOptions.FillAndExpand,
-                Children =
+                Icon = new FileImageSource
                 {
-                    new StackLayout
-                    {
-                        Orientation = StackOrientation.Horizontal,
-                        Padding = new Thickness(0, 70, 0, 40),
-                        Children =
-                        {
-                            new Check
-                            {
-                                DisplayStyle = CheckDisplayStyle.Small
-                            },
-                            new Label
-                            {
-                                Text = "Do not repeat",
-                            }
-                        }
-                    }
-                }
+                    File = "image/a.jpg",
+                },
+                Command = new Command(() =>
+                {
+                    Console.WriteLine("jpg button1 Command!!");
+                    _popUp3?.Dismiss();
+                    _popUp3 = null;
+                })
             };
+
+            _jpgIconButton2 = new MenuItem()
+            {
+                Icon = new FileImageSource
+                {
+                    File = "image/b.jpg",
+                },
+                Command = new Command(() =>
+                {
+                    Console.WriteLine("jpg button2 Command!!");
+                    _popUp3?.Dismiss();
+                    _popUp3 = null;
+                })
+            };
+
             _popUp3 = new TwoButtonPopup();
             _popUp3.SetValue(TwoButtonPopup.TitleProperty, "Popup title");
             _popUp3.SetValue(TwoButtonPopup.ContentProperty, _content);
@@ -237,24 +271,19 @@ height. This has two button in action area and title text in title area";
 
             _popUp3.BackButtonPressed += (s, e) =>
             {
-                _popUp3.Dismiss();
+                _popUp3?.Dismiss();
+                _popUp3 = null;
                 label1.Text = "Popup3 is dismissed";
             };
 
-            _popUp1.FirstButton.Clicked += (s, e) => Console.WriteLine("First(share) button clicked!");
-            _popUp1.SecondButton.Clicked += (s, e) => Console.WriteLine("Second(delete) button clicked!");
-
-            _popUp2.FirstButton.Clicked += (s, e) => Console.WriteLine("_popUp2 First button clicked!");
-            _popUp2.SecondButton.Clicked += (s, e) => Console.WriteLine("_popUp2 Second button clicked!");
-
             _popUp3.FirstButton.Clicked += (s, e) => Console.WriteLine("_popUp3 First button clicked!");
             _popUp3.SecondButton.Clicked += (s, e) => Console.WriteLine("_popUp3 Second button clicked!");
-
         }
 
 
         private void OnTwoButtonTextClicked(object sender, EventArgs e)
         {
+            createPopup1();
             _popUp1.FirstButton = _leftButton;
             _popUp1.SecondButton = _rightButton;
             _popUp1.Show();
@@ -262,18 +291,36 @@ height. This has two button in action area and title text in title area";
 
         private void OnTwoButtonLongTextClicked(object sender, EventArgs e)
         {
+            createPopup2();
             _popUp2.Show();
         }
 
         private void OnLeftOnlyClicked(object sender, EventArgs e)
         {
+            createPopup1();
             _popUp1.FirstButton = _leftButton;
             _popUp1.SecondButton = null;
             _popUp1.Show();
+
+            Device.StartTimer(TimeSpan.FromMilliseconds(3000), () =>
+            {
+                _popUp1?.SetValue(TwoButtonPopup.TitleProperty, "Popup title changed");
+                _popUp1?.SetValue(TwoButtonPopup.ContentProperty, _content);
+                _popUp1?.SetValue(TwoButtonPopup.SecondButtonProperty, new MenuItem
+                {
+                    Text = "Dismiss",
+                    Command = new Command(() => {
+                        _popUp1?.Dismiss();
+                        _popUp1 = null;
+                    })
+                });
+                return false;
+            });
         }
 
         private void OnRightOnlyClicked(object sender, EventArgs e)
         {
+            createPopup1();
             _popUp1.FirstButton = null;
             _popUp1.SecondButton = _rightButton;
             _popUp1.Show();
@@ -281,6 +328,7 @@ height. This has two button in action area and title text in title area";
 
         private void OnLeftNoIconClicked(object sender, EventArgs e)
         {
+            createPopup1();
             _popUp1.FirstButton = _noIconLeftButton;
             _popUp1.SecondButton = _rightButton;
             _popUp1.Show();
@@ -288,6 +336,7 @@ height. This has two button in action area and title text in title area";
 
         private void OnRightNoIconClicked(object sender, EventArgs e)
         {
+            createPopup1();
             _popUp1.FirstButton = _leftButton;
             _popUp1.SecondButton = _noIconRightButton;
             _popUp1.Show();
@@ -295,6 +344,7 @@ height. This has two button in action area and title text in title area";
 
         private void OnRightJpgIconClicked(object sender, EventArgs e)
         {
+            createPopup3();
             _popUp3.Show();
         }
     }


### PR DESCRIPTION
### Description of Change ###
Change Dismiss() from hide popup to dimiss and remove all resources on TwoButton/Information/Toast popup

- change Dismiss() from hide pop-up to dismis pop-up.
- dispose all resource when called Dissmissed Event handler.
- change TwoButtonPopup/InformationPopup TCs follow to behavior change.
- fix TwoButtonPopup's Left button occupied whole window when right button is null 
- fix progress circle is running even after IsProgressRunning value set false.


### Bugs Fixed ###
- Fix TwoButtonPopup's Left button occupied whole window when right button is null 
  (WearableUIGallery -> TwoButtonPopup-> Left button only button click -> check left button.)

- Fix progress circle is running even after IsProgressRunning value set false.
 (WearableUIGallery -> InformationPopup-> Process text button click  -> wait 3 seconds 
-> progress shoud be removed but it still remain. )


### API Changes ###
None

### Behavioral Changes ###
Previous Popup only hide and remain resources when user called Dismiss() method. but from now on, All resource  will be removed when called Dismiss(). 

