### PR TITLE
fix issue that not applying Value and BarAngle on CircleSliderSurfaceItem

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleSliderSurfaceItemImplements.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleSliderSurfaceItemImplements.cs
@@ -42,7 +42,6 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             if (item.BackgroundLineWidth != -1) BackgroundLineWidth = item.BackgroundLineWidth;
             if (item.BackgroundRadius != -1) BackgroundRadius = item.BackgroundRadius;
 
-            BarAngle = item.BarAngle;
             BarAngleOffset = item.BarAngleOffset;
             BarAngleMaximum = item.BarAngleMaximum;
             BarAngleMinimum = item.BarAngleMinimum;
@@ -53,7 +52,16 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             Minimum = item.Minimum;
             Maximum = item.Maximum;
             Step = item.Increment;
-            Value = item.Value;
+
+            if (item.Value == item.Minimum && item.BarAngle != 0)
+            {
+                BarAngle = item.BarAngle;
+            }
+            else
+            {
+                Value = item.Value;
+            }
+
             IsEnabled = item.IsEnabled;
 
             if (item.IsVisible) Show();
@@ -85,6 +93,10 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             else if (args.PropertyName == CircleSliderSurfaceItem.BarAngleProperty.PropertyName)
             {
                 BarAngle = _item.BarAngle;
+                if (_item.Value != Value)
+                {
+                    _item.Value = Value;
+                }
             }
             else if (args.PropertyName == CircleSliderSurfaceItem.BarAngleOffsetProperty.PropertyName)
             {
@@ -118,6 +130,10 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             else if (args.PropertyName == CircleSliderSurfaceItem.ValueProperty.PropertyName)
             {
                 if (_item.Value != Value) Value = _item.Value;
+                if (_item.BarAngle != BarAngle)
+                {
+                    _item.BarAngle = BarAngle;
+                }
             }
             else if (args.PropertyName == CircleSliderSurfaceItem.IsEnabledProperty.PropertyName)
             {

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
@@ -292,8 +292,6 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 _secondButton.Unrealize();
                 _secondButton = null;
             }
-
-           // _popUp.SetPartContent("button2", _secondButton);
         }
 
         void UpdateTitle()


### PR DESCRIPTION
### Description of Change ###
fix issue that not applying Value and BarAngle on CircleSliderSurfaceItem.
BarAngle and Value is interconnected. Each bindable object should be changed follow to other value changed.


### Bugs Fixed ###
fix issue that not applying Value and BarAngle on CircleSliderSurfaceItem
WeaabelUIGallery -> SurfaceItem -> CircleSlider1 TC  ->  press enable and disable button several times
-> circle bar length doesn't change follow to Value and BarAngle .

ItemPropertyChanged was not called when 'Value' and 'BarAngle' is set because each bindable object value is same as old value.

### API Changes ###
None

### Behavioral Changes ###
None
