### PR TITLE
Add string Value in SelectedEventArgs class for Radio

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms/Radio.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/Radio.cs
@@ -114,7 +114,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         static void IsSelectedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var radioButton = (Radio)bindable;
-            radioButton.Selected?.Invoke(radioButton, new SelectedEventArgs((bool)newValue));
+            radioButton.Selected?.Invoke(radioButton, new SelectedEventArgs(radioButton.Value, (bool)newValue));
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/SelectedEventArgs.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/SelectedEventArgs.cs
@@ -29,15 +29,22 @@ namespace Tizen.Wearable.CircularUI.Forms
         /// </summary>
         /// <param name="value">The boolean value that checks whether the RadioButton is selected.</param>
         /// <since_tizen> 4 </since_tizen>
-        public SelectedEventArgs(bool value)
+        public SelectedEventArgs(string value, bool isSelected)
         {
             Value = value;
+            IsSelected = isSelected;
         }
 
         /// <summary>
-        /// Gets the value object for the SelectedEventArgs object.
+        /// Gets the Value for the SelectedEventArgs object.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public bool Value { get; private set; }
+        public string Value { get; private set; }
+
+        /// <summary>
+        /// Gets the IsSelected for the SelectedEventArgs object.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public bool IsSelected { get; private set; }
     }
 }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCRadioListView.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCRadioListView.xaml.cs
@@ -33,7 +33,8 @@ namespace WearableUIGallery.TC
             Radio radio = sender as Radio;
             if (radio != null)
             {
-                Console.WriteLine($"<<OnSelected>>  Radio Value:{radio.Value}, GroupName:{radio.GroupName}, IsSelected:{radio.IsSelected}");
+                Console.WriteLine($"<<OnSelected>>  args.Value:{args.Value}, args.IsSelected:{args.IsSelected}");
+                Console.WriteLine($"<<OnSelected>>  Radio Value:{radio.Value}, IsSelected:{radio.IsSelected}, GroupName:{radio.GroupName}");
             }
         }
     }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCRadioStackLayout.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCRadioStackLayout.xaml.cs
@@ -33,7 +33,8 @@ namespace WearableUIGallery.TC
             Radio radio = sender as Radio;
             if (radio != null)
             {
-                Console.WriteLine($"<<OnSelected>>  Radio Value:{radio.Value}, GroupName:{radio.GroupName}, IsSelected:{radio.IsSelected}");
+                Console.WriteLine($"<<OnSelected>>  args.Value:{args.Value}, args.IsSelected:{args.IsSelected}");
+                Console.WriteLine($"<<OnSelected>>  Radio Value:{radio.Value}, IsSelected:{radio.IsSelected}, GroupName:{radio.GroupName}");
             }
         }
     }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCRadioViewModel.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCRadioViewModel.cs
@@ -102,7 +102,6 @@ namespace WearableUIGallery.TC
             {
                 if (e.PropertyName == "IsSelected")
                 {
-                    Console.WriteLine($"Sound.PropertyChanged IsSelected:{Sound.IsSelected}");
                     if (Sound.IsSelected) RadioLabel1 = "Sound";
                 }
             };
@@ -111,7 +110,6 @@ namespace WearableUIGallery.TC
             {
                 if (e.PropertyName == "IsSelected")
                 {
-                    Console.WriteLine($"Vibrate.PropertyChanged IsSelected:{Vibrate.IsSelected}");
                     if (Vibrate.IsSelected) RadioLabel1 = "Vibrate";
                 }
             };
@@ -120,7 +118,6 @@ namespace WearableUIGallery.TC
             {
                 if (e.PropertyName == "IsSelected")
                 {
-                    Console.WriteLine($"Mute.PropertyChanged IsSelected:{Mute.IsSelected}");
                     if (Mute.IsSelected) RadioLabel1 = "Mute";
                 }
             };


### PR DESCRIPTION
### Description of Change ###
SelectedEventArgs only send boolean value of IsSelected when Selected event occur.
In Event handler. need more information about which radio item changed.( this is Value of Radio)
Add Radio.Value on SelectedEventArgs for distinguish which radio is changed. 
change name from Value to IsSelected.


### Bugs Fixed ###
None


### API Changes ###
Added:
 - Add string Value in SelectedEventArgs.

Changed:
 - Change name  : bool  Value -> bool IsSelected.

### Behavioral Changes ###
None

