### PR TITLE
fix issue of transparent bg of Popup in PopupEntry

### DIFF
--- a/doc/guide/PopupEntry.md
+++ b/doc/guide/PopupEntry.md
@@ -30,7 +30,7 @@ When PopupEntry is used:
 - The `TextColor` inside the input pop up is also the same as the `TextColor` of the `PopupEntry`.
 - The [IsPassword](https://developer.xamarin.com/api/property/Xamarin.Forms.Entry.IsPassword/) property of the input pop up is also the same as the `PopupEntry`.
 
-**WARNING: If you set the `PopupEntry` width under the specific size(e.g 280), the `PopupEntry` can be truncated follow to device native layout.**
+**WARNING: If you set the `PopupEntry` width under the specific size(e.g 280), the `PopupEntry` can be truncated follow to device native theme.**
 
 # How to use
 

--- a/doc/guide/PopupEntry.md
+++ b/doc/guide/PopupEntry.md
@@ -26,9 +26,11 @@ The `Entry` is not visible because it is masked by the IME.
 The above image is the same as using `PopupEntry`, It can type text while watching it properly.
 
 When PopupEntry is used:
-- The `BackgroundColor` of the input pop up is the same as the `BackgroundColor` of the `PopupEntry`.
+- The `BackgroundColor` of the input pop up is the same as the `BackgroundColor` of the `PopupEntry`. The default color of the `PopupEntry` is set if you don't set the `BackgroundColor`.
 - The `TextColor` inside the input pop up is also the same as the `TextColor` of the `PopupEntry`.
 - The [IsPassword](https://developer.xamarin.com/api/property/Xamarin.Forms.Entry.IsPassword/) property of the input pop up is also the same as the `PopupEntry`.
+
+**WARNING: If you set the `PopupEntry` width under the specific size(e.g 280), the `PopupEntry` can be truncated follow to device native layout.**
 
 # How to use
 
@@ -41,11 +43,22 @@ When PopupEntry is used:
              xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
              x:Class="WearableUIGallery.TC.TCPopupEntry">
     <ContentPage.Content>
-        <w:CircleStackLayout>
-            <w:PopupEntry BackgroundColor="Gray" TextColor="Blue" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
-            <w:PopupEntry Placeholder="Foobar" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
-            <w:PopupEntry IsPassword="True" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
-        </w:CircleStackLayout>
+		<StackLayout Padding="20,40,20,40">
+			<w:PopupEntry
+				BackgroundColor="Gray"
+				HorizontalOptions="FillAndExpand"
+				TextColor="Blue"
+				VerticalOptions="CenterAndExpand" />
+			<w:PopupEntry
+				HorizontalOptions="FillAndExpand"
+				Placeholder="Foobar"
+				VerticalOptions="CenterAndExpand" />
+			<w:PopupEntry
+				HorizontalOptions="FillAndExpand"
+				IsPassword="True"
+				Placeholder="Password"
+				VerticalOptions="CenterAndExpand" />
+		</StackLayout>
     </ContentPage.Content>
 </ContentPage>
 ```

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
@@ -127,14 +127,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
             _editor.Text = Control.Text;
 
-            var edjeObj = Control.EdjeObject;
-            edjeObj.GetColorClass("layout/editfield/bg",
-                out int r, out int g, out int b, out int a,
-                out _, out _, out _, out _,
-                out _, out _, out _, out _);
-
-            _defaultColor = new ElmSharp.Color(r, g, b, a);
-
+            _defaultColor = new ElmSharp.Color(40, 40, 40, 255); //editfield bg default color
             _editor.TextColor = Control.TextColor;
             _editorPopup.Color = Control.BackgroundColor == default(ElmSharp.Color) ? _defaultColor : Control.BackgroundColor;
 

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
@@ -1,18 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
-             x:Class="WearableUIGallery.TC.TCPopupEntry">
-    <ContentPage.Content>
-        <w:CircleStackLayout>
-            <w:PopupEntry BackgroundColor="Gray"
-                          VerticalOptions="CenterAndExpand"
-                          HorizontalOptions="CenterAndExpand"
-                          TextColor="Blue"
-                          WidthRequest="100"/>
-            <w:PopupEntry Placeholder="Foobar"
-                          VerticalOptions="CenterAndExpand"
-                          HorizontalOptions="CenterAndExpand" />
-        </w:CircleStackLayout>
-    </ContentPage.Content>
+<ContentPage
+	x:Class="WearableUIGallery.TC.TCPopupEntry"
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms">
+	<ContentPage.Content>
+		<StackLayout Padding="20,40,20,40">
+			<w:PopupEntry
+				BackgroundColor="Gray"
+				HorizontalOptions="FillAndExpand"
+				TextColor="Blue"
+				VerticalOptions="CenterAndExpand" />
+			<w:PopupEntry
+				HorizontalOptions="FillAndExpand"
+				Placeholder="Foobar"
+				VerticalOptions="CenterAndExpand" />
+			<w:PopupEntry
+				HorizontalOptions="FillAndExpand"
+				IsPassword="True"
+				Placeholder="Password"
+				VerticalOptions="CenterAndExpand" />
+		</StackLayout>
+	</ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
### Description of Change ###
- fix issue of transparent bg of Popup in PopupEntry
- modify PopupEntry TC
- add warnning of PopupEntry truncated issue. (this is native limitation)


### Bugs Fixed ###
- when you didn't set background color of PopupEntry. and then you click PopupEntry -> Popup shows .
Popup's background color is transparent .

- set default color with hardcoding (before it read colorset from edje but this code was not worked)


### API Changes ###
N/A

### Behavioral Changes ###
N/A

