### PR TITLE
Fix first scroll issue in IndexPage

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/IndexPageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/IndexPageRenderer.cs
@@ -39,8 +39,8 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         const int ItemMaxCount = 20;
         const int OddMiddleItem = 10;
         const int EvenMiddleItem = 11;
-        private int _pageIndex;
-        private int _changedByScroll;
+        private int _pageIndex = 0;
+        private int _changedByScroll = 0;
 
         Index _index;
         List<IndexItem> _items = new List<IndexItem>();
@@ -49,8 +49,8 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         Scroller _scroller;
 
         private ElmSharp.Size _layoutBound;
-        bool _isInitalized;
-        bool _isUpdateCarousel;
+        bool _isInitalized = false;
+        bool _isUpdateCarousel = false;
 
         protected override void OnElementChanged(ElementChangedEventArgs<IndexPage> e)
         {
@@ -78,6 +78,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         protected override void OnElementReady()
         {
+            //Console.WriteLine("OnElementReady()");
             base.OnElementReady();
             _isInitalized = true;
             UpdateCarouselContent();
@@ -154,7 +155,8 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         private void OnPageScrolled(object sender, EventArgs e)
         {
-            if(_isUpdateCarousel){
+            Console.WriteLine($"OnPageScrolled()  _pageIndex:{_pageIndex}, HorizontalPageIndex:{_scroller.HorizontalPageIndex}, _isUpdateCarousel:{_isUpdateCarousel}");
+            if (_isUpdateCarousel){
                 _isUpdateCarousel = false;
                 return;
             }
@@ -176,6 +178,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void OnPagesChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            //Console.WriteLine("OnPagesChanged()");
             UpdateCarouselContent();
 
             //update Index items.
@@ -198,6 +201,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void OnCurrentPageChanged(object sender, EventArgs ea)
         {
+            //Console.WriteLine($"OnCurrentPageChanged() _pageIndex:{_pageIndex}, current:{Element.Children.IndexOf(Element.CurrentPage)}, _changedByScroll:{_changedByScroll}");
             if (IsChangedByScroll())
                 return;
 
@@ -208,6 +212,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 _pageIndex = Element.Children.IndexOf(Element.CurrentPage);
                 if (previousPageIndex != _pageIndex)
                 {
+                    //Console.WriteLine($"OnCurrentPageChanged() ScrollTo _pageIndex:{_pageIndex}");
                     // notify disappearing/appearing pages and scroll to the requested page
                     (Element.Children[previousPageIndex] as IPageController)?.SendDisappearing();
                     _scroller.ScrollTo(_pageIndex, 0, false);
@@ -226,6 +231,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateCarouselContent()
         {
+            //Console.WriteLine("UpdateCarouselContent()");
             _innerContainer.UnPackAll();
             foreach (var page in Element.Children)
             {
@@ -236,10 +242,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _isUpdateCarousel = true;
             _scroller.ScrollTo(_pageIndex, 0, false);
             Element.UpdateFocusTreePolicy();
+            _isUpdateCarousel = false;
         }
 
         private void UpdateIndexItem()
         {
+            //Console.WriteLine($"UpdateIndexItem() _pageIndex:{_pageIndex}");
             _index.Style = IndexStyle.Circle;
             _items.Clear();
 


### PR DESCRIPTION
### Description of Change ###
Fix first scroll issue in IndexPage . 
when scroll page from first page to second page. following issue are happened.
- CurrentPageChanged event is not raised
- Page indicator is still indicating first index.


### Bugs Fixed ###
- OnPageScrolled is ignored. fixed this issue.


### API Changes ###
N/A

### Behavioral Changes ###
N/A

