### PR TITLE
Fix Issue #119

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleListView.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleListView.cs
@@ -38,6 +38,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         public CircleListView(EvasObject parent, CircleSurface surface) : base(parent, surface)
         {
         }
+
         public VisualElement Header
         {
             get => _header;
@@ -246,6 +247,19 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
         }
 
+        void UpdateHeaderHeightForGroup(bool isPreviousOfGroup)
+        {
+            if (Header == null) return;
+            if (isPreviousOfGroup)
+            {
+                Header.MinimumHeightRequest = 83; // correct visible height on the Group Header
+            }
+            else
+            {
+                Header.MinimumHeightRequest = 115; // correct visible height on the None group header
+            }
+        }
+
         void UpdateHeader()
         {
             GenItemClass cls = null;
@@ -276,6 +290,14 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 {
                     FirstItem.UpdateItemClass(cls, new TypedItemContext(Header, type));
                 }
+            }
+
+            if (Header != null && FirstItem?.Next != null)
+            {
+                var nextCtx = FirstItem.Next?.Data as ListViewItemContext;
+                var isNextItemIsGroupHeader = nextCtx == null ? false : nextCtx.IsGroupItem;
+
+                UpdateHeaderHeightForGroup(isNextItemIsGroupHeader);
             }
         }
         void UpdateFooter()
@@ -309,6 +331,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             item.IsEnabled = cell.IsEnabled;
             item.Deleted += ItemDeletedHandler;
             _itemContexts[cell] = item;
+
+
+            if (Header != null && item == FirstItem.Next)
+            {
+                UpdateHeaderHeightForGroup(IsGroup);
+            }
 
             if (!IsGroup)
             {

--- a/test/WearableUIGallery/WearableUIGallery/AppViewModel.cs
+++ b/test/WearableUIGallery/WearableUIGallery/AppViewModel.cs
@@ -37,7 +37,9 @@ namespace WearableUIGallery
                     new TCDescribe { Title = "GroupList", Class = typeof(TCGroupList) },
                     new TCDescribe { Title = "CircleListView", Class = typeof(TCCircleListView) },
                     new TCDescribe { Title = "ViewCell", Class = typeof(TCViewCell) },
-                    new TCDescribe { Title = "ListViewNormal", Class = typeof(TCListPage) }
+                    new TCDescribe { Title = "ListViewNormal", Class = typeof(TCListPage) },
+                    new TCDescribe { Title = "HeaderWithGroup", Class = typeof(TCCircleListViewGroupHeader) },
+                    new TCDescribe { Title = "HeaderWithoutGroup", Class = typeof(TCCircleListViewHeaderWithoutGroup) }
                 }
             });
             TCs.Add(new TCDescribe

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewGroupHeader.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewGroupHeader.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<w:CirclePage
+    x:Class="WearableUIGallery.TC.TCCircleListViewGroupHeader"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:WearableUIGallery"
+    xmlns:sys="clr-namespace:System;assembly=netstandard"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
+    RotaryFocusObject="{x:Reference mylist}">
+    <w:CirclePage.Content>
+        <w:CircleListView x:Name="mylist" IsGroupingEnabled="True">
+            <w:CircleListView.ItemsSource>
+                <x:Array x:Key="array" Type="{x:Type sys:Array}">
+                    <x:Array Type="{x:Type sys:String}">
+                        <x:String>Item 1</x:String>
+                        <x:String>Item 2</x:String>
+                        <x:String>Item 3</x:String>
+                        <x:String>Item 4</x:String>
+                    </x:Array>
+                    <x:Array Type="{x:Type sys:String}">
+                        <x:String>Item 5</x:String>
+                        <x:String>Item 6</x:String>
+                        <x:String>Item 7</x:String>
+                        <x:String>Item 8</x:String>
+                    </x:Array>
+                    <x:Array Type="{x:Type sys:String}">
+                        <x:String>Item 9</x:String>
+                        <x:String>Item 10</x:String>
+                        <x:String>Item 11</x:String>
+                        <x:String>Item 12</x:String>
+                    </x:Array>
+                </x:Array>
+            </w:CircleListView.ItemsSource>
+            <w:CircleListView.Header>
+                <x:String>Header</x:String>
+            </w:CircleListView.Header>
+            <w:CircleListView.HeaderTemplate>
+                <DataTemplate>
+                    <Label w:CircleListView.CancelEffect="True"
+                           FontSize="10"
+                           HorizontalTextAlignment="Center"
+                           Text="{Binding .}"
+                           TextColor="#4CCDFC"
+                           VerticalTextAlignment="Center" />
+                </DataTemplate>
+            </w:CircleListView.HeaderTemplate>
+            <w:CircleListView.ItemTemplate>
+                <DataTemplate>
+                    <ViewCell>
+                        <Label Text="{Binding .}"
+                            HeightRequest="120"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"/>
+                    </ViewCell>
+                </DataTemplate>
+            </w:CircleListView.ItemTemplate>
+        </w:CircleListView>
+    </w:CirclePage.Content>
+</w:CirclePage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewGroupHeader.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewGroupHeader.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Tizen.Wearable.CircularUI.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace WearableUIGallery.TC
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TCCircleListViewGroupHeader : CirclePage
+	{
+		public TCCircleListViewGroupHeader ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewHeaderWithoutGroup.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewHeaderWithoutGroup.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<w:CirclePage
+    x:Class="WearableUIGallery.TC.TCCircleListViewHeaderWithoutGroup"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:WearableUIGallery"
+    xmlns:sys="clr-namespace:System;assembly=netstandard"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
+    RotaryFocusObject="{x:Reference mylist}">
+    <w:CirclePage.Content>
+        <w:CircleListView x:Name="mylist">
+            <w:CircleListView.ItemsSource>
+                <x:Array x:Key="array" Type="{x:Type sys:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                    <x:String>Item 4</x:String>
+                    <x:String>Item 5</x:String>
+                    <x:String>Item 6</x:String>
+                    <x:String>Item 7</x:String>
+                    <x:String>Item 8</x:String>
+                    <x:String>Item 9</x:String>
+                    <x:String>Item 10</x:String>
+                    <x:String>Item 11</x:String>
+                    <x:String>Item 12</x:String>
+                </x:Array>
+            </w:CircleListView.ItemsSource>
+            <w:CircleListView.Header>
+                <x:String>Header</x:String>
+            </w:CircleListView.Header>
+            <w:CircleListView.HeaderTemplate>
+                <DataTemplate>
+                    <Label w:CircleListView.CancelEffect="True"
+                           FontSize="10"
+                           HorizontalTextAlignment="Center"
+                           Text="{Binding .}"
+                           TextColor="#4CCDFC"
+                           VerticalTextAlignment="Center" />
+                </DataTemplate>
+            </w:CircleListView.HeaderTemplate>
+            <w:CircleListView.ItemTemplate>
+                <DataTemplate>
+                    <ViewCell>
+                        <Label Text="{Binding .}"
+                            HeightRequest="120"
+                            VerticalTextAlignment="Center"
+                            HorizontalTextAlignment="Center"/>
+                    </ViewCell>
+                </DataTemplate>
+            </w:CircleListView.ItemTemplate>
+        </w:CircleListView>
+    </w:CirclePage.Content>
+</w:CirclePage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewHeaderWithoutGroup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewHeaderWithoutGroup.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tizen.Wearable.CircularUI.Forms;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace WearableUIGallery.TC
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TCCircleListViewHeaderWithoutGroup : CirclePage
+	{
+		public TCCircleListViewHeaderWithoutGroup ()
+		{
+			InitializeComponent ();
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###
Now, CircleListView Header has a predefined minimum height for each case that is before group header or not.
 

### Bugs Fixed ###
- CircleListView Header has a minimum height to an 83px if placed before the group item or has a 115px according to an internal UX guide.
