### PR TITLE
Fix not updating issue of PopupEntry

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
@@ -134,6 +134,8 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void HidePopup()
         {
+            Control.TextChanged -= OnTextChanged;
+
             if (_IMEState != Interop.EFL.InputPanelState.Hide)
             {
                 _editor.HideInputPanel();
@@ -164,6 +166,8 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
             _editor.MoveCursorEnd();
             _editor.ShowInputPanel();
+
+            Control.TextChanged += OnTextChanged;
         }
 
         void EditorStateChanged(IntPtr data, IntPtr ctx, int value)
@@ -184,16 +188,28 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         void UpdatePopupBackgroundColor()
         {
             Xamarin.Forms.Color bgColor = ((PopupEntry)Element).PopupBackgroundColor;
-            Console.WriteLine($"UpdatePopupBackgroundColor bgColor:{bgColor}");
             if (bgColor == Xamarin.Forms.Color.Default)
             {
-                Console.WriteLine($"set default color");
                 _popupBackgroundColor = DefaultColor;
             }
             else
             {
                 _popupBackgroundColor = bgColor.ToNative();
-                Console.WriteLine($"set default color _popupBackgroundColor:{_popupBackgroundColor}");
+            }
+        }
+
+        void OnTextChanged(object sender, EventArgs e)
+        {
+            if (_editor != null)
+            {
+                if (_editor.Text != Control.Text)
+                {
+                    _editor.Text = Control.Text;
+                    if (!_editor.IsFocused)
+                    {
+                        _editor.MoveCursorEnd();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###
-PopupEntry editor is not updating Element text that is inserted by code.
-Add event handler for base entry Control, and check whether editor is same as control's text.


### Bugs Fixed ###
- Add TextChanged event handler for EntryPopup.
- type any text, and then set blank at EntryPopup.Text Property.
- Entry should be blank and  handler's  e.NewTextValue should be blank , but it has previous text.
- EntryPopup editor was not updated following to Element.TextProperty.

