### PR TITLE
[Information/TwoButtonPopup] fix issue that  button event handler is not invoked

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
@@ -102,6 +102,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 {
                     _layout.Unrealize();
                     _layout = null;
+                    _popUp.BackButtonPressed -= BackButtonPressedHandler;
                     _popUp.Unrealize();
                     _popUp = null;
                 }
@@ -260,7 +261,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                     ((IMenuItemController)BottomButton).Activate();
                 };
 
-                if(_buttonBgColor != Color.Default)
+                if (_buttonBgColor != Color.Default)
                 {
                     Log.Debug(FormsCircularUI.Tag, $"InformationPopup set button background color:{_buttonBgColor.ToNative()}");
                     _bottomButton.BackgroundColor = _buttonBgColor.ToNative();
@@ -268,6 +269,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
             else
             {
+                _bottomButton.Unrealize();
                 _bottomButton = null;
             }
 
@@ -329,14 +331,46 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         public void Dismiss()
         {
+            _popUp.Hide();
+
+            if (_bottomButton != null)
+            {
+                _bottomButton.Unrealize();
+                _bottomButton = null;
+                _popUp.SetPartContent("button1", null);
+            }
+
+            if (_box != null)
+            {
+                _box.Unrealize();
+                _box = null;
+            }
+
+            if (_progress != null)
+            {
+                _progress.Unrealize();
+                _progress = null;
+            }
+
+            if (_progressLabel != null)
+            {
+                _progressLabel.Unrealize();
+                _progressLabel = null;
+            }
+
             if (_popUp != null)
             {
-                _popUp.Dismiss();
+                _layout.Unrealize();
+                _layout = null;
+                _popUp.BackButtonPressed -= BackButtonPressedHandler;
+                _popUp.Unrealize();
+                _popUp = null;
             }
         }
 
         void OnDismissed(object sender, EventArgs e)
         {
+            Log.Debug(FormsCircularUI.Tag, $"OnDismissed called");
             Dispose();
         }
     }

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
@@ -89,6 +89,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                     _secondButton.Unrealize();
                     _secondButton = null;
                 }
+
                 if (_nativeContent != null)
                 {
                     _nativeContent.Unrealize();
@@ -355,14 +356,38 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         public void Dismiss()
         {
+            if (_firstButton != null)
+            {
+                _firstButton.Unrealize();
+                _firstButton = null;
+                _popUp.SetPartContent("button1", null);
+            }
+
+            if (_secondButton != null)
+            {
+                _secondButton.Unrealize();
+                _secondButton = null;
+                _popUp.SetPartContent("button2", null);
+            }
+
+            if (_nativeContent != null)
+            {
+                _nativeContent.Unrealize();
+                _nativeContent = null;
+            }
+
             if (_popUp != null)
             {
-                _popUp.Dismiss();
+                _layout.Unrealize();
+                _layout = null;
+                _popUp.Unrealize();
+                _popUp = null;
             }
         }
 
         void OnDismissed(object sender, EventArgs e)
         {
+            Log.Debug(FormsCircularUI.Tag, $"OnDismissed called");
             Dispose();
         }
     }

--- a/src/Tizen.Wearable.CircularUI.Forms/InformationPopup.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/InformationPopup.cs
@@ -17,6 +17,8 @@
 using System;
 using Xamarin.Forms;
 using Tizen.Wearable.CircularUI.Forms;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Tizen.Wearable.CircularUI.Forms
 {
@@ -47,6 +49,8 @@ namespace Tizen.Wearable.CircularUI.Forms
         public static readonly BindableProperty BottomButtonProperty = BindableProperty.Create(nameof(BottomButton), typeof(MenuItem), typeof(InformationPopup), null);
 
         IInformationPopup _popUp;
+
+        static IList<IInformationPopup> _popUpList = new ObservableCollection<IInformationPopup>();
 
         /// <summary>
         /// Occurs when the device's back button is pressed.
@@ -117,6 +121,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         public void Show()
         {
             _popUp.Show();
+            _popUpList.Add(_popUp);
         }
 
         /// <summary>
@@ -126,6 +131,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         public void Dismiss()
         {
             _popUp.Dismiss();
+            _popUpList.Remove(_popUp);
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/TwoButtonPopup.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/TwoButtonPopup.cs
@@ -17,6 +17,8 @@
 using Xamarin.Forms;
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Tizen.Wearable.CircularUI.Forms
 {
@@ -95,6 +97,8 @@ namespace Tizen.Wearable.CircularUI.Forms
         public static readonly BindableProperty SecondButtonProperty = BindableProperty.Create(nameof(SecondButton), typeof(MenuItem), typeof(TwoButtonPopup), null);
 
         ITwoButtonPopup _popUp;
+
+        static IList<ITwoButtonPopup> _popUpList = new ObservableCollection<ITwoButtonPopup>();
 
         /// <summary>
         /// Occurs when the device's back button is pressed.
@@ -185,6 +189,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         public void Show()
         {
             _popUp.Show();
+            _popUpList.Add(_popUp);
         }
 
         /// <summary>
@@ -194,6 +199,7 @@ namespace Tizen.Wearable.CircularUI.Forms
         public void Dismiss()
         {
             _popUp.Dismiss();
+            _popUpList.Remove(_popUp);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
Fix issue #199 
Information Popup's bottom button event handler is not called When multiple InformationPopup has shown.

### Bugs Fixed ###
Sometimes, button event handler is not called because managed instance was destroy by GC but platform native widget is still displayed. so click event didn't pass to managed area.
add managing list of popup for preventing unwanted removing by GC

### API Changes ###
N/A

### Behavioral Changes ###
N/A
