### PR TITLE
Fix obsoleted property in X.F 4.0.0

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
@@ -41,7 +41,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         ElmSharp.EvasImage _bgImageObject;
         ElmSharp.Layout _surfaceLayout;
         ElmSharp.Button _actionButton;
-        string _bgImage;
+        ImageSource _bgImage;
 
         ElmSharp.Wearable.CircleSurface _surface;
         IRotaryFocusable _currentRotaryFocusObject;
@@ -52,7 +52,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         public CirclePageRenderer()
         {
-            RegisterPropertyHandler(Xamarin.Forms.Page.BackgroundImageProperty, UpdateBackgroundImage);
+            RegisterPropertyHandler(Xamarin.Forms.Page.BackgroundImageSourceProperty, UpdateBackgroundImage);
             RegisterPropertyHandler(CirclePage.ActionButtonProperty, UpdateActionButton);
             RegisterPropertyHandler(CirclePage.RotaryFocusObjectProperty, UpdateRotaryFocusObject);
         }
@@ -112,17 +112,19 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         }
         protected void UpdateBackgroundImage(bool initialize)
         {
-            if (initialize && string.IsNullOrWhiteSpace(Element.BackgroundImage))
+            if (initialize && Element.BackgroundImageSource.IsNullOrEmpty())
                 return;
-            if (string.IsNullOrWhiteSpace(Element.BackgroundImage))
+
+            var bgImageSource = Element.BackgroundImageSource as FileImageSource;
+            if (bgImageSource.IsNullOrEmpty())
             {
                 _bgImageObject.File = null;
                 _bgImage = null;
             }
             else
             {
-                _bgImageObject.File = ResourcePath.GetPath(Element.BackgroundImage);
-                _bgImage = Element.BackgroundImage;
+                _bgImageObject.File = ResourcePath.GetPath(bgImageSource);
+                _bgImage = Element.BackgroundImageSource;
             }
             UpdateBackground();
         }
@@ -229,7 +231,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateBackground()
         {
-            if (string.IsNullOrEmpty(_bgImage))
+            if (_bgImage.IsNullOrEmpty())
             {
                 _bgImageObject.Hide();
             }
@@ -257,9 +259,10 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 Element.ActionButton.PropertyChanged += OnActionButtonItemChanged;
                 _actionButton.Text = Element.ActionButton.Text;
                 _actionButton.IsEnabled = Element.ActionButton.IsEnable;
-                if (Element.ActionButton.Icon != null)
+                if (!Element.ActionButton.IconImageSource.IsNullOrEmpty())
                 {
-                    var path = ResourcePath.GetPath(Element.ActionButton.Icon);
+                    var imageSource = Element.ActionButton.IconImageSource as FileImageSource;
+                    var path = ResourcePath.GetPath(imageSource);
                     var buttonImage = new ElmSharp.Image(_actionButton);
                     buttonImage.LoadAsync(path);
                     buttonImage.Show();
@@ -325,11 +328,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         void AddToolbarItem(XToolbarItem item)
         {
             var moreOptionItem = new ActionMoreOptionItem();
-            var icon = item.Icon;
-            if (!string.IsNullOrEmpty(icon.File))
+            var icon = item.IconImageSource;
+            if (!icon.IsNullOrEmpty())
             {
+                var iconSource = icon as FileImageSource;
                 var img = new ElmSharp.Image(_moreOption);
-                img.LoadAsync(ResourcePath.GetPath(icon.File));
+                img.LoadAsync(ResourcePath.GetPath(iconSource));
                 moreOptionItem.Icon = img;
             }
             var text = item.Text;

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/ImageExtension.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/ImageExtension.cs
@@ -1,0 +1,11 @@
+﻿
+using Xamarin.Forms;
+
+namespace Tizen.Wearable.CircularUI.Forms.Renderer
+{
+    internal static class ImageExtension
+    {
+        internal static bool IsNullOrEmpty(this ImageSource imageSource) =>
+        imageSource == null || imageSource.IsEmpty;
+    }
+}

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
@@ -243,16 +243,13 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
                 if (!string.IsNullOrEmpty(BottomButton.Text))_bottomButton.Text = BottomButton.Text;
 
-                if (BottomButton.Icon != null)
+                if (!BottomButton.IconImageSource.IsNullOrEmpty())
                 {
-                    var iconPath = BottomButton.Icon.File;
-                    if (!string.IsNullOrEmpty(iconPath))
-                    {
-                        var buttonImage = new ElmSharp.Image(_bottomButton);
-                        buttonImage.LoadAsync(ResourcePath.GetPath(iconPath));
-                        buttonImage.Show();
-                        _bottomButton.SetPartContent("elm.swallow.content", buttonImage);
-                    }
+                    var iconSource = BottomButton.IconImageSource as FileImageSource;
+                    var buttonImage = new ElmSharp.Image(_bottomButton);
+                    buttonImage.LoadAsync(ResourcePath.GetPath(iconSource));
+                    buttonImage.Show();
+                    _bottomButton.SetPartContent("elm.swallow.content", buttonImage);
                 }
 
                 _bottomButton.Clicked += (s, e) =>

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageRenderer.cs
@@ -116,12 +116,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 if (Element.SecondButton is ColorMenuItem)
                 {
                     var item = ((ColorMenuItem)Element.SecondButton);
-                    _widget.ShowButton2(item.Text, item.IconImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton2(item.Text, item.IconImageSource as FileImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
                 }
                 else
                 {
                     var item = Element.SecondButton;
-                    _widget.ShowButton2(item.Text, item.IconImageSource, () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton2(item.Text, item.IconImageSource as FileImageSource, () => ((IMenuItemController)item).Activate());
                 }
             }
             else
@@ -138,12 +138,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 if (Element.FirstButton is ColorMenuItem)
                 {
                     var item = ((ColorMenuItem)Element.FirstButton);
-                    _widget.ShowButton1(item.Text, item.IconImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton1(item.Text, item.IconImageSource as FileImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
                 }
                 else
                 {
                     var item = Element.FirstButton;
-                    _widget.ShowButton1(item.Text, item.IconImageSource, () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton1(item.Text, item.IconImageSource as FileImageSource, () => ((IMenuItemController)item).Activate());
                 }
             }
             else

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageRenderer.cs
@@ -32,7 +32,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         public TwoButtonPageRenderer()
         {
-            RegisterPropertyHandler(TwoButtonPage.BackgroundImageProperty, UpdateBackgroundImage);
+            RegisterPropertyHandler(TwoButtonPage.BackgroundImageSourceProperty, UpdateBackgroundImage);
             RegisterPropertyHandler(TwoButtonPage.FirstButtonProperty, UpdateFirstButton);
             RegisterPropertyHandler(TwoButtonPage.SecondButtonProperty, UpdateSecondButton);
             RegisterPropertyHandler(TwoButtonPage.OverlapProperty, UpdateOverlap);
@@ -98,13 +98,14 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateBackgroundImage(bool initialize)
         {
-            if (initialize && string.IsNullOrEmpty(Element.BackgroundImage))
+            if (initialize && Element.BackgroundImageSource.IsNullOrEmpty())
                 return;
 
-            if (string.IsNullOrEmpty(Element.BackgroundImage))
+            var bgImage = Element.BackgroundImageSource as FileImageSource;
+            if (bgImage.IsNullOrEmpty())
                 _widget.File = null;
             else
-                _widget.File = ResourcePath.GetPath(Element.BackgroundImage);
+                _widget.File = ResourcePath.GetPath(bgImage);
         }
 
         void UpdateSecondButton(bool initialize)
@@ -115,12 +116,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 if (Element.SecondButton is ColorMenuItem)
                 {
                     var item = ((ColorMenuItem)Element.SecondButton);
-                    _widget.ShowButton2(item.Text, item.Icon, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton2(item.Text, item.IconImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
                 }
                 else
                 {
                     var item = Element.SecondButton;
-                    _widget.ShowButton2(item.Text, item.Icon, () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton2(item.Text, item.IconImageSource, () => ((IMenuItemController)item).Activate());
                 }
             }
             else
@@ -137,12 +138,12 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 if (Element.FirstButton is ColorMenuItem)
                 {
                     var item = ((ColorMenuItem)Element.FirstButton);
-                    _widget.ShowButton1(item.Text, item.Icon, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton1(item.Text, item.IconImageSource, item.BackgroundColor.ToNative(), () => ((IMenuItemController)item).Activate());
                 }
                 else
                 {
                     var item = Element.FirstButton;
-                    _widget.ShowButton1(item.Text, item.Icon, () => ((IMenuItemController)item).Activate());
+                    _widget.ShowButton1(item.Text, item.IconImageSource, () => ((IMenuItemController)item).Activate());
                 }
             }
             else

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageWidget.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageWidget.cs
@@ -17,9 +17,7 @@
 using ElmSharp;
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
+using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using Xamarin.Forms.Platform.Tizen.Native;
 
@@ -105,15 +103,15 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             base.OnUnrealize();
         }
 
-        public void ShowButton1(string text, string image, Color backgroundColor, Action action) => ShowButton(0, "popup/circle/left", "actionbtn1", text, backgroundColor, image, action);
-        public void ShowButton1(string text, string image, Action action) => ShowButton1(text, image, Color.Default, action);
+        public void ShowButton1(string text, ImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(0, "popup/circle/left", "actionbtn1", text, backgroundColor, image, action);
+        public void ShowButton1(string text, ImageSource image, Action action) => ShowButton1(text, image, ElmSharp.Color.Default, action);
         public void ShowButton1(string text, Action action) => ShowButton1(text, null, action);
         public void ShowButton1(string text) => ShowButton1(text, null, null);
 
         public void HideButton1() => HideButton(0);
-        public void ShowButton2(string text, string image, Color backgroundColor, Action action) => ShowButton(1, "popup/circle/right", "actionbtn2", text, backgroundColor, image, action);
-        public void ShowButton2(string text, string image, Action action) => ShowButton2(text, image, Color.Default, action);
-        public void ShowButton2(string text, string image) => ShowButton2(text, image, null);
+        public void ShowButton2(string text, ImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(1, "popup/circle/right", "actionbtn2", text, backgroundColor, image, action);
+        public void ShowButton2(string text, ImageSource image, Action action) => ShowButton2(text, image, ElmSharp.Color.Default, action);
+        public void ShowButton2(string text, ImageSource image) => ShowButton2(text, image, null);
         public void ShowButton2(string text) => ShowButton2(text, null, null);
         public void HideButton2() => HideButton(1);
 
@@ -134,7 +132,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             Canvas.Geometry = rect;
         }
 
-        void ShowButton(int id, string style, string part, string text, Color buttonBgColor, string image = null, Action action = null)
+        void ShowButton(int id, string style, string part, string text, ElmSharp.Color buttonBgColor, ImageSource image = null, Action action = null)
         {
             HideButton(id);
 
@@ -143,16 +141,16 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 Text = text,
                 Style = style
             };
-            if (!string.IsNullOrEmpty(image))
+            if (!image.IsNullOrEmpty())
             {
-                var path = ResourcePath.GetPath(image);
+                var path = ResourcePath.GetPath(image as FileImageSource);
                 var buttonImage = new ElmSharp.Image(_buttons[id]);
                 buttonImage.LoadAsync(path);
                 buttonImage.Show();
                 _buttons[id].SetPartContent("elm.swallow.content", buttonImage);
             }
 
-            if (buttonBgColor != Color.Default)
+            if (buttonBgColor != ElmSharp.Color.Default)
             {
                 _buttons[id].BackgroundColor = buttonBgColor;
             }

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageWidget.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPageWidget.cs
@@ -103,15 +103,15 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             base.OnUnrealize();
         }
 
-        public void ShowButton1(string text, ImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(0, "popup/circle/left", "actionbtn1", text, backgroundColor, image, action);
-        public void ShowButton1(string text, ImageSource image, Action action) => ShowButton1(text, image, ElmSharp.Color.Default, action);
+        public void ShowButton1(string text, FileImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(0, "popup/circle/left", "actionbtn1", text, backgroundColor, image, action);
+        public void ShowButton1(string text, FileImageSource image, Action action) => ShowButton1(text, image, ElmSharp.Color.Default, action);
         public void ShowButton1(string text, Action action) => ShowButton1(text, null, action);
         public void ShowButton1(string text) => ShowButton1(text, null, null);
 
         public void HideButton1() => HideButton(0);
-        public void ShowButton2(string text, ImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(1, "popup/circle/right", "actionbtn2", text, backgroundColor, image, action);
-        public void ShowButton2(string text, ImageSource image, Action action) => ShowButton2(text, image, ElmSharp.Color.Default, action);
-        public void ShowButton2(string text, ImageSource image) => ShowButton2(text, image, null);
+        public void ShowButton2(string text, FileImageSource image, ElmSharp.Color backgroundColor, Action action) => ShowButton(1, "popup/circle/right", "actionbtn2", text, backgroundColor, image, action);
+        public void ShowButton2(string text, FileImageSource image, Action action) => ShowButton2(text, image, ElmSharp.Color.Default, action);
+        public void ShowButton2(string text, FileImageSource image) => ShowButton2(text, image, null);
         public void ShowButton2(string text) => ShowButton2(text, null, null);
         public void HideButton2() => HideButton(1);
 
@@ -132,7 +132,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             Canvas.Geometry = rect;
         }
 
-        void ShowButton(int id, string style, string part, string text, ElmSharp.Color buttonBgColor, ImageSource image = null, Action action = null)
+        void ShowButton(int id, string style, string part, string text, ElmSharp.Color buttonBgColor, FileImageSource image = null, Action action = null)
         {
             HideButton(id);
 
@@ -143,7 +143,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             };
             if (!image.IsNullOrEmpty())
             {
-                var path = ResourcePath.GetPath(image as FileImageSource);
+                var path = ResourcePath.GetPath(image);
                 var buttonImage = new ElmSharp.Image(_buttons[id]);
                 buttonImage.LoadAsync(path);
                 buttonImage.Show();

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
@@ -244,13 +244,13 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
                 if (!string.IsNullOrEmpty(FirstButton.Text)) _firstButton.Text = FirstButton.Text;
 
-                if (FirstButton.Icon != null)
+                if (!FirstButton.IconImageSource.IsNullOrEmpty())
                 {
-                    var iconPath = FirstButton.Icon.File;
-                    if (!string.IsNullOrEmpty(iconPath))
+                    var iconSource = FirstButton.IconImageSource as FileImageSource;
+                    if (!iconSource.IsNullOrEmpty())
                     {
                         var buttonImage = new ElmSharp.Image(_firstButton);
-                        buttonImage.LoadAsync(ResourcePath.GetPath(iconPath));
+                        buttonImage.LoadAsync(ResourcePath.GetPath(iconSource));
                         buttonImage.Show();
                         _firstButton.SetPartContent("elm.swallow.content", buttonImage);
                     }
@@ -290,13 +290,13 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
                 if (!string.IsNullOrEmpty(SecondButton.Text)) _secondButton.Text = SecondButton.Text;
 
-                if (SecondButton.Icon != null)
+                if (!SecondButton.IconImageSource.IsNullOrEmpty())
                 {
-                    var iconPath = SecondButton.Icon.File;
-                    if (!string.IsNullOrEmpty(iconPath))
+                    var iconSource = SecondButton.IconImageSource as FileImageSource;
+                    if (!iconSource.IsNullOrEmpty())
                     {
                         var buttonImage = new ElmSharp.Image(_secondButton);
-                        buttonImage.LoadAsync(ResourcePath.GetPath(iconPath));
+                        buttonImage.LoadAsync(ResourcePath.GetPath(iconSource));
                         buttonImage.Show();
                         _secondButton.SetPartContent("elm.swallow.content", buttonImage);
                     }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
@@ -62,7 +62,12 @@ namespace WearableUIGallery.TC
             _textIconBottomButton = new MenuItem
             {
                 Text = "OK",
-                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_delete.png"),
+#pragma warning disable CS0618 // Icon is obsolete. This code is for checking backword compatibility.
+                Icon = new FileImageSource
+#pragma warning restore CS0618
+                {
+                    File = "image/tw_ic_popup_btn_delete.png",
+                },
                 Command = new Command(() =>
                 {
                     Console.WriteLine("text&icon bottom button Command!!");

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCInformationPopup.xaml.cs
@@ -50,10 +50,7 @@ namespace WearableUIGallery.TC
 
             _iconBottomButton = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_delete.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("icon bottom button Command!!");
@@ -65,10 +62,7 @@ namespace WearableUIGallery.TC
             _textIconBottomButton = new MenuItem
             {
                 Text = "OK",
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_delete.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("text&icon bottom button Command!!");

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPage.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPage.xaml.cs
@@ -41,10 +41,7 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new MenuItem
                 {
-                    Icon = new FileImageSource
-                    {
-                        File = "image/b_option_list_icon_delete.png",
-                    },
+                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
                     Command = _viewModel.Command1
                 };
 
@@ -58,10 +55,7 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new MenuItem
                 {
-                    Icon = new FileImageSource
-                    {
-                        File = "image/b_option_list_icon_share.png",
-                    },
+                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_share.png"),
                     Command = _viewModel.Command2
                 };
                 SecondButton = newItem;
@@ -112,10 +106,7 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new ColorMenuItem
                 {
-                    Icon = new FileImageSource
-                    {
-                        File = "image/b_option_list_icon_delete.png",
-                    },
+                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
                     BackgroundColor = Color.Green,
                     Command = _viewModel.Command1
                 };
@@ -130,10 +121,7 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new ColorMenuItem
                 {
-                    Icon = new FileImageSource
-                    {
-                        File = "image/b_option_list_icon_share.png",
-                    },
+                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_share.png"),
                     BackgroundColor = Color.Blue,
                     Command = _viewModel.Command2
                 };

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPage.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPage.xaml.cs
@@ -41,7 +41,12 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new MenuItem
                 {
-                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
+#pragma warning disable CS0618 // Icon is obsolete. This code is for checking backword compatibility.
+                    Icon = new FileImageSource
+#pragma warning restore CS0618
+                    {
+                        File = "image/b_option_list_icon_delete.png",
+                    },
                     Command = _viewModel.Command1
                 };
 
@@ -55,7 +60,12 @@ namespace WearableUIGallery.TC
             {
                 var newItem = new MenuItem
                 {
-                    IconImageSource = ImageSource.FromFile("image/b_option_list_icon_share.png"),
+#pragma warning disable CS0618 // Icon is obsolete. This code is for checking backword compatibility.
+                    Icon = new FileImageSource
+#pragma warning restore CS0618
+                    {
+                        File = "image/b_option_list_icon_share.png",
+                    },
                     Command = _viewModel.Command2
                 };
                 SecondButton = newItem;

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
@@ -44,10 +44,7 @@ namespace WearableUIGallery.TC
 
             _leftButton = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/b_option_list_icon_share.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/b_option_list_icon_share.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("left button1 Command!!");
@@ -58,10 +55,7 @@ namespace WearableUIGallery.TC
 
             _rightButton = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/b_option_list_icon_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("right button1 Command!!");
@@ -186,10 +180,7 @@ height. This has two button in action area and title text in title area";
         {
             var leftButton2 = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_check.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_check.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("left button2 Command!!");
@@ -200,10 +191,7 @@ height. This has two button in action area and title text in title area";
 
             var rightButton2 = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_delete.png"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("right button2 Command!!");
@@ -233,10 +221,7 @@ height. This has two button in action area and title text in title area";
         {
             _jpgIconButton1 = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/a.jpg",
-                },
+                IconImageSource = ImageSource.FromFile("image/a.jpg"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("jpg button1 Command!!");
@@ -247,10 +232,7 @@ height. This has two button in action area and title text in title area";
 
             _jpgIconButton2 = new MenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/b.jpg",
-                },
+                IconImageSource = ImageSource.FromFile("image/b.jpg"),
                 Command = new Command(() =>
                 {
                     Console.WriteLine("jpg button2 Command!!");
@@ -351,10 +333,7 @@ height. This has two button in action area and title text in title area";
 
             _colorleftButton = new ColorMenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/b_option_list_icon_share.png",
-                },
+                IconImageSource= ImageSource.FromFile("image/b_option_list_icon_share.png"),
                 BackgroundColor = Color.Green,
                 Command = new Command(() =>
                 {
@@ -375,10 +354,7 @@ height. This has two button in action area and title text in title area";
 
             _colorRightButton = new ColorMenuItem
             {
-                Icon = new FileImageSource
-                {
-                    File = "image/b_option_list_icon_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
                 BackgroundColor = Color.Blue,
                 Command = new Command(() =>
                 {

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopup.xaml.cs
@@ -44,7 +44,12 @@ namespace WearableUIGallery.TC
 
             _leftButton = new MenuItem
             {
-                IconImageSource = ImageSource.FromFile("image/b_option_list_icon_share.png"),
+#pragma warning disable CS0618 // Icon is obsolete. This code is for checking backword compatibility.
+                Icon = new FileImageSource
+#pragma warning restore CS0618
+                {
+                    File = "image/b_option_list_icon_share.png",
+                },
                 Command = new Command(() =>
                 {
                     Console.WriteLine("left button1 Command!!");
@@ -55,7 +60,12 @@ namespace WearableUIGallery.TC
 
             _rightButton = new MenuItem
             {
-                IconImageSource = ImageSource.FromFile("image/b_option_list_icon_delete.png"),
+#pragma warning disable CS0618 // Icon is obsolete. This code is for checking backword compatibility.
+                Icon = new FileImageSource
+#pragma warning restore CS0618
+                {
+                    File = "image/b_option_list_icon_delete.png",
+                },
                 Command = new Command(() =>
                 {
                     Console.WriteLine("right button1 Command!!");

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopupCmd.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCTwoButtonPopupCmd.xaml.cs
@@ -71,10 +71,7 @@ namespace WearableUIGallery.TC
             FirstButton = new MenuItem()
             {
                 // Set icon
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_delete.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_delete.png"),
                 //Set command
                 Command = new Command(() =>
                 {
@@ -86,10 +83,7 @@ namespace WearableUIGallery.TC
             SecondButton = new MenuItem()
             {
                 // Set icon
-                Icon = new FileImageSource
-                {
-                    File = "image/tw_ic_popup_btn_check.png",
-                },
+                IconImageSource = ImageSource.FromFile("image/tw_ic_popup_btn_check.png"),
                 //Set command
                 Command = new Command(() =>
                 {


### PR DESCRIPTION
### Description of Change ###
- Menuitem.icon and Page.BackgroundImage was deprecated in Xamarin.Forms 4.0.0
- Remove implementation for  MenuItem.Icon and Page.BackgroundImage 
- Add Implementatin for MenuItem.IconImageSource and Page.BackgroundImageSource
- Change TC code in WearableUIGallery

### Bugs Fixed ###
- N/A


### API Changes ###
Added:
 - MenuItem.IconImageSource
 - Page.BackgroundImageSource

 Removed:
-  Page.BackgroundImage ( This is not supported from X.F 4.0.0 )

### Behavioral Changes ###
remove Page.BackgroundImage implementation in CircularUI renderer. ( This is not supported from X.F 4.0.0 )
Add Implementatin for MenuItem.IconImageSource and Page.BackgroundImageSource
MenuItem.Icon was binding with MenuItem.IconImageSource(X.F core). So. previous  app's Icon property  works in current renderer.

