### PR TITLE
Fix not setting ReturnType value in PopupEntry

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
@@ -113,7 +113,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _editor.AllowFocus(true);
             _editor.Show();
 
-            _editor.SetInputPanelReturnKeyType(InputPanelReturnKeyType.Done);
+            _editor.SetInputPanelReturnKeyType(Element.ReturnType.ToInputPanelReturnKeyType());
 
             _editor.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled, Element.IsTextPredictionEnabled);
 
@@ -246,6 +246,30 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             else
             {
                 HidePopup();
+            }
+        }
+    }
+
+    internal static class EntryExtensions
+    {
+        internal static InputPanelReturnKeyType ToInputPanelReturnKeyType(this ReturnType returnType)
+        {
+            switch (returnType)
+            {
+                case ReturnType.Go:
+                    return InputPanelReturnKeyType.Go;
+                case ReturnType.Next:
+                    return InputPanelReturnKeyType.Next;
+                case ReturnType.Send:
+                    return InputPanelReturnKeyType.Send;
+                case ReturnType.Search:
+                    return InputPanelReturnKeyType.Search;
+                case ReturnType.Done:
+                    return InputPanelReturnKeyType.Done;
+                case ReturnType.Default:
+                    return InputPanelReturnKeyType.Default;
+                default:
+                    throw new NotImplementedException($"ReturnType {returnType} not supported");
             }
         }
     }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
@@ -18,6 +18,7 @@
                     Placeholder="Foobar"
                     PlaceholderColor="Blue"
                     VerticalOptions="CenterAndExpand"
+                    ReturnType="Search"
                     x:Name="PopupEntry1"/>
                 <w:PopupEntry
                     AutomationId="popupEntry2"


### PR DESCRIPTION
### Description of Change ###
Fix issue (https://github.com/Samsung/Tizen.CircularUI/issues/207)
ReturnType value was not set in PopupEntry

### Bugs Fixed ###
ReturnType of  PopupEntry was always set  'ReturnType.Done'.
Fix not setting ReturnType issue.


### API Changes ###
N/A

### Behavioral Changes ###
N/A

