### PR TITLE
Fix CirclePage.BackgroundImageSource

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
@@ -123,6 +123,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
             else
             {
+                _bgImageObject.IsFilled = true;
                 _bgImageObject.File = ResourcePath.GetPath(bgImageSource);
                 _bgImage = Element.BackgroundImageSource;
             }


### PR DESCRIPTION
### Description of Change ###
`_bgImageObject.IsFilled` set to true, before set `_bgImageObject.File`
It allocates an image buffer area.

### Bugs Fixed ###
 Fixs : #213 


### API Changes ###
None

### Behavioral Changes ###
CirclePage.BackgroundImageSource is working

