### PR TITLE
Fix span text displaying issue in PopupEntry

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleStepperRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleStepperRenderer.cs
@@ -40,6 +40,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             RegisterPropertyHandler(Stepper.MaximumProperty, UpdateMaximum);
             RegisterPropertyHandler(Stepper.ValueProperty, UpdateValue);
             RegisterPropertyHandler(Stepper.IncrementProperty, UpdateIncrement);
+            RegisterPropertyHandler(CircleStepper.IsWrapEnabledProperty, UpdateWrapEnabled);
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<CircleStepper> e)
@@ -181,6 +182,14 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             if (null != Control && null != Element)
             {
                 Control.Step = Element.Increment;
+            }
+        }
+
+        void UpdateWrapEnabled()
+        {
+            if (null != Control && null != Element)
+            {
+                Control.IsWrapEnabled = Element.IsWrapEnabled;
             }
         }
     }

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleStepper.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleStepper.cs
@@ -50,26 +50,61 @@ namespace Tizen.Wearable.CircularUI.Forms
         public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(CircleStepper), null);
 
         /// <summary>
+        /// BindableProperty. Identifies whether min/max value is wrapped or not.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public static readonly BindableProperty IsWrapEnabledProperty = BindableProperty.CreateAttached(nameof(IsWrapEnabled), typeof(bool), typeof(CircleStepper), true);
+
+        /// <summary>
         /// Gets or sets Marker color
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         [Obsolete("MarkerColor is obsolete as of Tizen.NET version 4.0.0 and is no longer supported")]
-        public Color MarkerColor { get => (Color)GetValue(MarkerColorProperty); set => SetValue(MarkerColorProperty, value); }
+        public Color MarkerColor
+        {
+            get => (Color)GetValue(MarkerColorProperty);
+            set => SetValue(MarkerColorProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets length of Marker
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         [Obsolete("MarkerLineWidth is obsolete as of Tizen.NET version 4.0.0 and is no longer supported")]
-        public int MarkerLineWidth { get => (int)GetValue(MarkerLineWidthProperty); set => SetValue(MarkerLineWidthProperty, value); }
+        public int MarkerLineWidth
+        {
+            get => (int)GetValue(MarkerLineWidthProperty);
+            set => SetValue(MarkerLineWidthProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets format in which Value is shown
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public string LabelFormat { get => (string)GetValue(LabelFormatProperty); set => SetValue(LabelFormatProperty, value); }
+        public string LabelFormat
+        {
+            get => (string)GetValue(LabelFormatProperty);
+            set => SetValue(LabelFormatProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets title
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public string Title { get => (string)GetValue(TitleProperty); set => SetValue(TitleProperty, value); }
+        public string Title
+        {
+            get => (string)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a status of Value is wrapped.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public bool IsWrapEnabled
+        {
+            get => (bool)GetValue(IsWrapEnabledProperty);
+            set => SetValue(IsWrapEnabledProperty, value);
+        }
     }
 }

--- a/test/WearableUIGallery/WearableUIGallery.Tizen.Wearable/WearableUIGallery.Tizen.Wearable.csproj
+++ b/test/WearableUIGallery/WearableUIGallery.Tizen.Wearable/WearableUIGallery.Tizen.Wearable.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
 
   <!-- Property Group for Tizen40 Project -->
   <PropertyGroup>
@@ -29,10 +29,6 @@
   <!-- Include Nuget Package for Tizen Project building -->
   <ItemGroup>
     <PackageReference Include="Tizen.Appium.Forms" Version="1.0.0-preview" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/WearableUIGallery/WearableUIGallery/AppViewModel.cs
+++ b/test/WearableUIGallery/WearableUIGallery/AppViewModel.cs
@@ -94,7 +94,8 @@ namespace WearableUIGallery
                     new TCDescribe { Title = "Grid", Class = typeof(TCCircleStepper) },
                     new TCDescribe { Title = "AbsoluteLayout", Class = typeof(TCCircleStepper2) },
                     new TCDescribe { Title = "Title", Class = typeof(TCCircleStepper3) },
-                    new TCDescribe { Title = "LabelFormat", Class = typeof(TCCircleStepper4) }
+                    new TCDescribe { Title = "LabelFormat", Class = typeof(TCCircleStepper4) },
+                    new TCDescribe { Title = "Wrap", Class = typeof(TCCircleStepper5) }
                 }
             });
             TCs.Add(new TCDescribe

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleStepper5.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleStepper5.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<w:CirclePage
+    x:Class="WearableUIGallery.TC.TCCircleStepper5"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:WearableUIGallery"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
+    RotaryFocusObject="{x:Reference StepperUnit}">
+    <w:CirclePage.Content>
+        <StackLayout
+            VerticalOptions="CenterAndExpand"
+            Orientation="Vertical">
+            <w:CircleStepper
+                    AutomationId="stepper"
+                    x:Name="StepperUnit"
+                    HeightRequest="350"
+                    Title="stepper"
+                    HorizontalOptions="CenterAndExpand"
+                    Increment="1"
+                    LabelFormat="%1.1f"
+                    Maximum="100.0"
+                    Minimum="0.0"
+                    IsWrapEnabled="False"
+                    Value="50" />
+        </StackLayout>
+    </w:CirclePage.Content>
+    <w:CirclePage.ActionButton>
+        <w:ActionButtonItem x:Name="Button1" Text="Wrap Disable" Clicked="ActionButtonClicked"/>
+    </w:CirclePage.ActionButton>
+</w:CirclePage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleStepper5.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleStepper5.xaml.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Tizen.Wearable.CircularUI.Forms;
+using Xamarin.Forms.Xaml;
+using System;
+
+namespace WearableUIGallery.TC
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TCCircleStepper5 : CirclePage
+    {
+
+        public TCCircleStepper5()
+        {
+            InitializeComponent ();
+        }
+
+        void ActionButtonClicked(object sender, EventArgs args)
+        {
+            StepperUnit.IsWrapEnabled = !StepperUnit.IsWrapEnabled;
+            Console.WriteLine($"StepperUnit.IsWrapEnabled:{StepperUnit.IsWrapEnabled}");
+            Button1.Text = StepperUnit.IsWrapEnabled ? "Wrap Enabled" : "Wrap Disabled";
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Fix span text displaying issue in PopupEntry.
This is workaround patch for efl native behavior changing in Tizen 6.0

### Bugs Fixed ###
- span text is  displayed in tizen 6.0 emul and device
- The issue is reproducible in Xamarin.Forms app with IsReadOnly property set `false`

issue screen shot 
![PopupEntry_issue_before](https://user-images.githubusercontent.com/31116585/71612234-53fe4f00-2be2-11ea-898a-71242943e40f.png)

after fix
![PopupEntry_issue_after](https://user-images.githubusercontent.com/31116585/71612269-9889ea80-2be2-11ea-8e40-a284eeb53248.png)


### API Changes ###
None

### Behavioral Changes ###
None

