### PR TITLE
Change protection level for CircleScrollViewRenderer

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleScrollViewRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleScrollViewRenderer.cs
@@ -28,7 +28,7 @@ using XForms = Xamarin.Forms.Forms;
 
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
 {
-    class CircleScrollViewRenderer : ViewRenderer<CircleScrollView, ElmSharp.Wearable.CircleScroller>
+    public class CircleScrollViewRenderer : ViewRenderer<CircleScrollView, ElmSharp.Wearable.CircleScroller>
     {
         Xamarin.Forms.Platform.Tizen.Native.Box _scrollCanvas;
         ElmSharp.SmartEvent _scrollAnimationStart, _scrollAnimationStop;


### PR DESCRIPTION
### Description of Change ###
Change protection level for `CircleScrollViewRenderer` from private to public.
This will allow the renderer to be accessed or inherited.


### Bugs Fixed ###
- N/A


### API Changes ###
N/A

### Behavioral Changes ###
N/A

