### PR TITLE
Fix span text displaying issue in PopupEntry

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
@@ -61,6 +61,11 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 // Set Text again for apply text style because IsEditable reset the style of text
                 Control.Text = string.Empty;
                 Control.Text = Element.Text;
+                if (Control is IEntry ie)
+                {
+                    ie.Placeholder = string.Empty;
+                    ie.Placeholder = Element.Placeholder;
+                }
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
Fix span text displaying issue in PopupEntry.
This is workaround patch for efl native behavior changing in Tizen 6.0

### Bugs Fixed ###
- span text is  displayed in tizen 6.0 emul and device
- The issue is reproducible in Xamarin.Forms app with IsReadOnly property set `false`

issue screen shot 
![PopupEntry_issue_before](https://user-images.githubusercontent.com/31116585/71612234-53fe4f00-2be2-11ea-898a-71242943e40f.png)

after fix
![PopupEntry_issue_after](https://user-images.githubusercontent.com/31116585/71612269-9889ea80-2be2-11ea-8e40-a284eeb53248.png)

### API Changes ###
None

### Behavioral Changes ###
None

