### PR TITLE
Use Forms's GetHandler

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/ListViewCache.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/ListViewCache.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using ElmSharp;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
-using Xamarin.Forms.Internals;
+using XForms = Xamarin.Forms.Forms;
 
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
 {
@@ -50,7 +50,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
             else
             {
-                renderer = Registrar.Registered.GetHandler<CellRenderer>(type);
+                renderer = XForms.GetHandler<CellRenderer>(type);
                 if (renderer == null)
                 {
                     throw new ArgumentNullException("Unsupported cell type");

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/MediaPlayerImpl.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/MediaPlayerImpl.cs
@@ -21,8 +21,8 @@ using System.Threading.Tasks;
 using Tizen.Multimedia;
 using Tizen.Wearable.CircularUI.Forms.Renderer;
 using Xamarin.Forms;
-using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Tizen;
+using XForms = Xamarin.Forms.Forms;
 
 [assembly: Xamarin.Forms.Dependency(typeof(MediaPlayerImpl))]
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
@@ -270,7 +270,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             {
                 return;
             }
-            IMediaSourceHandler handler = Registrar.Registered.GetHandlerForObject<IMediaSourceHandler>(_source);
+            IMediaSourceHandler handler = XForms.GetHandlerForObject<IMediaSourceHandler>(_source);
             await handler.SetSource(_player, _source);
         }
 


### PR DESCRIPTION
### Description of Change ###
This PR allows to you to use `StaticRegistrar` (introduced in [#8642](https://github.com/xamarin/Xamarin.Forms/pull/8642)) for CircularUI.

### Bugs Fixed ###
None

### API Changes ###
None

### Behavioral Changes ###
Using StaticRegistrar is allowed.
