### PR TITLE
Fix issue that newline and ampersand are not supported in Information & TwoButton Popup

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/InformationPopupImplementation.cs
@@ -274,9 +274,14 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateTitle()
         {
+            string title = _title?.Replace("&", "&amp;")
+                                  .Replace("<", "&lt;")
+                                  .Replace(">", "&gt;")
+                                  .Replace(Environment.NewLine, "<br>");
+
             if (!_isProgressRunning)
             {
-                _layout.SetPartText("elm.text.title", _title);
+                _layout.SetPartText("elm.text.title", title);
             }
             else
             {
@@ -286,14 +291,19 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateText()
         {
+            string text = _text?.Replace("&", "&amp;")
+                                .Replace("<", "&lt;")
+                                .Replace(">", "&gt;")
+                                .Replace(Environment.NewLine, "<br>");
+
             if (!_isProgressRunning)
             {
-                _layout.SetPartText("elm.text", _text);
+                _layout.SetPartText("elm.text", text);
             }
             else
             {
                 _layout.SetPartText("elm.text", null);
-                if (!string.IsNullOrEmpty(_text))
+                if (!string.IsNullOrEmpty(text))
                 {
                     if (_progressLabel == null)
                     {
@@ -302,7 +312,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                             TextStyle = "DEFAULT ='font=Tizen:style=Light color=#F9F9F9FF font_size=32 align=center valign=top wrap=word'",
                         };
                     }
-                    _progressLabel.Text = _text;
+                    _progressLabel.Text = text;
                     _progressLabel.Show();
                     if (_box != null)
                     {

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/TwoButtonPopupImplementation.cs
@@ -332,12 +332,20 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void UpdateTitle()
         {
-            _layout.SetPartText("elm.text.title", _title);
+            string title = _title?.Replace("&", "&amp;")
+                                  .Replace("<", "&lt;")
+                                  .Replace(">", "&gt;")
+                                  .Replace(Environment.NewLine, "<br>");
+            _layout.SetPartText("elm.text.title", title);
         }
 
         void UpdateText()
         {
-            _layout.SetPartText("elm.text", _text);
+            string text = _text?.Replace("&", "&amp;")
+                                .Replace("<", "&lt;")
+                                .Replace(">", "&gt;")
+                                .Replace(Environment.NewLine, "<br>");
+            _layout.SetPartText("elm.text", text);
         }
 
         public void Show()


### PR DESCRIPTION
### Description of Change ###
Fix issue that newline and ampersand are not supported in Information & TwoButton Popup


### Bugs Fixed ###
fix issue that reported in https://developer.tizen.org/forums/tizen-.net/carrige-return-popuptext

### API Changes ###
None

### Behavioral Changes ###
before
![InformationPopup_newline_notsupport](https://user-images.githubusercontent.com/31116585/75649006-2a6eac00-5c95-11ea-8872-534ad0ab999d.png)
![twobuttonPopup_newline_notsupport](https://user-images.githubusercontent.com/31116585/75649016-30648d00-5c95-11ea-9685-e55e9ef05273.png)


after
![Information_newline_support](https://user-images.githubusercontent.com/31116585/75649027-378b9b00-5c95-11ea-9f2a-6eac0526bc63.png)
![twobutton_newline_support](https://user-images.githubusercontent.com/31116585/75649032-3a868b80-5c95-11ea-9b65-b4788d8c148c.png)


