### PR TITLE
Add new FlatViewCell

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/FlatViewCellRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/FlatViewCellRenderer.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Tizen.Wearable.CircularUI.Forms;
+using Tizen.Wearable.CircularUI.Forms.Renderer;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(FlatViewCell), typeof(FlatViewCellRenderer))]
+namespace Tizen.Wearable.CircularUI.Forms.Renderer
+{
+    public class FlatViewCellRenderer : ViewCellRenderer
+    {
+        public FlatViewCellRenderer()
+        {
+            Style = "full_effect_off";
+        }
+    }
+}

--- a/src/Tizen.Wearable.CircularUI.Forms/FlatViewCell.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/FlatViewCell.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+
+namespace Tizen.Wearable.CircularUI.Forms
+{
+    /// <summary>
+    /// FlatViewCell contains a developer-defined Xamarin.Forms.View.
+    /// It has no fish-eye effect while ViewCell has fish-eye effect.
+    /// </summary>
+    /// <since_tizen> 6 </since_tizen>
+    public class FlatViewCell : ViewCell
+    {
+    }
+}

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewNoItemEffect.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewNoItemEffect.xaml
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<w:CirclePage
+    x:Class="WearableUIGallery.TC.TCCircleListViewNoItemEffect"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:WearableUIGallery.TC"
+    xmlns:sys="clr-namespace:System;assembly=netstandard"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms"
+    RotaryFocusObject="{x:Reference mylist}">
+    <w:CirclePage.Resources>
+        <DataTemplate x:Key="FlatItem">
+            <w:FlatViewCell>
+                <Grid>
+                    <BoxView HeightRequest="200" BackgroundColor="Blue"/>
+                    <Label Text="Flat ViewCell" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
+                </Grid>
+            </w:FlatViewCell>
+        </DataTemplate>
+        <DataTemplate x:Key="NormalItem">
+            <TextCell Text="{Binding .}" />
+        </DataTemplate>
+        <local:MyItemSelector x:Key="myItemSelector"
+                              FlatItemTemplate="{StaticResource FlatItem}"
+                              NormalItemTemplate="{StaticResource NormalItem}" />
+    </w:CirclePage.Resources>
+    <w:CirclePage.Content>
+        <w:CircleListView x:Name="mylist" ItemTapped="OnItemTapped" ItemTemplate="{StaticResource myItemSelector}">
+            <w:CircleListView.ItemsSource>
+                <x:Array Type="{x:Type sys:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                    <x:String>Item 4</x:String>
+                    <x:String>Item 5</x:String>
+                </x:Array>
+            </w:CircleListView.ItemsSource>
+            <w:CircleListView.Header>
+                <x:String>Header</x:String>
+            </w:CircleListView.Header>
+            <w:CircleListView.Footer>
+                <x:String>Footer</x:String>
+            </w:CircleListView.Footer>
+            <w:CircleListView.HeaderTemplate>
+                <DataTemplate>
+                    <Label
+                        w:CircleListView.CancelEffect="True"
+                        HeightRequest="120"
+                        FontAttributes="Bold"
+                        FontSize="Large"
+                        HorizontalTextAlignment="Center"
+                        VerticalTextAlignment="Center"
+                        Text="{Binding .}"
+                        TextColor="Red" />
+                </DataTemplate>
+            </w:CircleListView.HeaderTemplate>
+            <w:CircleListView.FooterTemplate>
+                <DataTemplate>
+                    <Label
+                        w:CircleListView.CancelEffect="True"
+                        HeightRequest="120"
+                        FontAttributes="Bold"
+                        FontSize="Large"
+                        HorizontalTextAlignment="Center"
+                        VerticalTextAlignment="Center"
+                        Text="{Binding .}"
+                        TextColor="Blue" />
+                </DataTemplate>
+            </w:CircleListView.FooterTemplate>
+        </w:CircleListView>
+    </w:CirclePage.Content>
+</w:CirclePage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewNoItemEffect.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleListViewNoItemEffect.xaml.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Xamarin.Forms;
+using Tizen.Wearable.CircularUI.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace WearableUIGallery.TC
+{
+
+    public class MyItemSelector : DataTemplateSelector
+    {
+        public DataTemplate FlatItemTemplate { get; set; }
+
+        public DataTemplate NormalItemTemplate { get; set; }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            if (item.ToString().Contains("Item 1"))
+            {
+                return FlatItemTemplate;
+            }
+            else
+            {
+                return NormalItemTemplate;
+            }
+        }
+    }
+
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TCCircleListViewNoItemEffect : CirclePage
+    {
+        public TCCircleListViewNoItemEffect()
+        {
+            InitializeComponent ();
+            Console.WriteLine($"location = {Shell.Current.CurrentState.Location.ToString()}");
+        }
+
+        public void OnItemTapped(object sender, ItemTappedEventArgs args)
+        {
+            Console.WriteLine($"OnItemTapped Item:{args.Item.ToString()}");
+        }
+    }
+}

--- a/test/WearableUIGallery/WearableUIGallery/TCData.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TCData.cs
@@ -43,6 +43,7 @@ namespace WearableUIGallery
                 Class = new TCTypes
                 {
                     new TCDescribe { Title = "NoFishEyeHeaderList", Class = typeof(TCCircleListViewNoEffect) },
+                    new TCDescribe { Title = "NoFishEyeItemList", Class = typeof(TCCircleListViewNoItemEffect) },
                     new TCDescribe { Title = "CircleListBehavior", Class = typeof(TCListAppender) },
                     new TCDescribe { Title = "GroupList", Class = typeof(TCGroupList) },
                     new TCDescribe { Title = "CircleListView", Class = typeof(TCCircleListView) },


### PR DESCRIPTION
### Description of Change ###
This PR adds a new ViewCell called `FlatViewCell`. 
**Important:** This new `FlatViewCell` uses the new item class style called `full_effect_off`and this style will be merged on 5.5 binary soon(API6).
Comparing to other existing cell styles, `full_effect_off` has no fish eye effect but is focus-able.
- `full` (ViewCell): Focus O / Fish Eye Effect O
- `full_off` (Header or Footer with CancelEffect enabled): Focus X / Fish Eye Effect X
- `full_effect_off`(FlatViewCell): Focus O / Fish Eye Effect X

### Bugs Fixed ###
- N/A

### API Changes ###
Added:
 - Add `FlatViewCell`
 - Add a TC for FlatViewCell


