### PR TITLE
Adds ICircleSurfaceProvider and ICircleSurfaceConsumer

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
@@ -81,6 +81,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
             if (e.NewElement != null)
             {
+                e.NewElement.CircleSurface = _surface;
                 e.NewElement.Appearing += OnPageAppearing;
                 e.NewElement.Disappearing += OnPageDisappearing;
                 var toolbarItems = e.NewElement.ToolbarItems as ObservableCollection<XToolbarItem>;

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleSurfaceViewRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleSurfaceViewRenderer.cs
@@ -51,6 +51,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
             if (e.NewElement != null)
             {
+                e.NewElement.CircleSurface = _circleSurface;
                 var items = e.NewElement.CircleSurfaceItems as ObservableCollection<ICircleSurfaceItem>;
                 items.CollectionChanged += OnCircleSurfaceItemsChanged;
                 foreach (var item in items)

--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleWidgetRendererExtension.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleWidgetRendererExtension.cs
@@ -14,38 +14,53 @@
  * limitations under the License.
  */
 
-using System;
+using ElmSharp.Wearable;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
+using XForms = Xamarin.Forms.Forms;
 
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
 {
     static class CircleWidgetRendererExtension
     {
-        internal static ElmSharp.Wearable.CircleSurface GetSurface(this IVisualElementRenderer renderer)
+        internal static CircleSurface GetSurface(this IVisualElementRenderer renderer)
         {
-            if (null != renderer.Element)
+            Element element = renderer.Element;
+            CircleSurface circleSurface = null;
+            if (element is ICircleSurfaceConsumer circleElement)
             {
-                Element element = renderer.Element;
-                while (element != null)
+                var provider = circleElement.CircleSurfaceProvider;
+                if (provider != null)
                 {
-                    if (element is CirclePage)
-                    {
-                        var circlePageRenderer = Platform.GetRenderer(element) as CirclePageRenderer;
-                        return circlePageRenderer?.CircleSurface;
-                    }
-                    foreach (var effect in element.Effects)
-                    {
-                        if (effect is TizenCircleSurfaceEffect)
-                        {
-                            return CircleSurfaceEffectBehavior.GetSurface(element) as ElmSharp.Wearable.CircleSurface;
-                        }
-                    }
-
-                    element = element.Parent;
+                    circleSurface = (CircleSurface)provider.CircleSurface;
+                }
+                else
+                {
+                    circleSurface = GetSurfaceRecursively(element);
                 }
             }
-            throw new CircleSurfaceNotFoundException();
+            return circleSurface??XForms.CircleSurface;
+        }
+
+        internal static CircleSurface GetSurfaceRecursively(Element element)
+        {
+            while (element != null)
+            {
+                if (element is CirclePage)
+                {
+                    var circlePageRenderer = Platform.GetRenderer(element) as CirclePageRenderer;
+                    return circlePageRenderer?.CircleSurface;
+                }
+                foreach (var effect in element.Effects)
+                {
+                    if (effect is TizenCircleSurfaceEffect)
+                    {
+                        return CircleSurfaceEffectBehavior.GetSurface(element) as CircleSurface;
+                    }
+                }
+                element = element.Parent;
+            }
+            return null;
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleDateTimeSelector.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleDateTimeSelector.cs
@@ -24,7 +24,7 @@ namespace Tizen.Wearable.CircularUI.Forms
     /// The CircleDateTimeSelector is a view that can change the value by bezel action by touching each item of "Year: Month: Day" and "Hour: Minute: AM / PM"
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public class CircleDateTimeSelector : Xamarin.Forms.View, IRotaryFocusable
+    public class CircleDateTimeSelector : Xamarin.Forms.View, IRotaryFocusable, ICircleSurfaceConsumer
     {
         /// <summary>
         /// BindableProperty. Identifies the MarkerColor bindable property.
@@ -156,6 +156,7 @@ namespace Tizen.Wearable.CircularUI.Forms
             get => (bool)GetValue(IsVisibleOfMinuteProperty);
             set => SetValue(IsVisibleOfMinuteProperty, value);
         }
+
         /// <summary>
         /// Gets or sets a boolean value that indicates whether the AmPm field type is visible.
         /// </summary>
@@ -165,5 +166,11 @@ namespace Tizen.Wearable.CircularUI.Forms
             get => (bool)GetValue(IsVisibleOfAmPmProperty);
             set => SetValue(IsVisibleOfAmPmProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a CircleSurfaceProvider.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public ICircleSurfaceProvider CircleSurfaceProvider { get; set; }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleListView.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleListView.cs
@@ -24,7 +24,7 @@ namespace Tizen.Wearable.CircularUI.Forms
     /// You can move the list through bezel action.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public class CircleListView : ListView, IRotaryFocusable
+    public class CircleListView : ListView, IRotaryFocusable, ICircleSurfaceConsumer
     {
         /// <summary>
         /// BindableProperty. Identifies the Header, Footer cancel the Fish Eye Effect or not.
@@ -60,5 +60,11 @@ namespace Tizen.Wearable.CircularUI.Forms
             get => (Color)GetValue(BarColorProperty);
             set => SetValue(BarColorProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a CircleSurfaceProvider.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public ICircleSurfaceProvider CircleSurfaceProvider { get; set; }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/CirclePage.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CirclePage.cs
@@ -27,7 +27,7 @@ namespace Tizen.Wearable.CircularUI.Forms
     /// It has an ActionButton, and can use the MenuItem type as text, icon, command, and so on.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public class CirclePage : ContentPage
+    public class CirclePage : ContentPage, ICircleSurfaceProvider
     {
         /// <summary>
         /// BindableProperty. Identifies the ActionButton bindable property.
@@ -64,6 +64,9 @@ namespace Tizen.Wearable.CircularUI.Forms
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Appeared { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public object CircleSurface { get; set; }
 
         /// <summary>
         /// Gets or sets ActionButton that presents a menu item and associates it with a command

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleScrollView.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleScrollView.cs
@@ -23,7 +23,7 @@ namespace Tizen.Wearable.CircularUI.Forms
     /// The CircleScrollView is extension of Xamarin.Forms.ScrollView.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public class CircleScrollView : ScrollView, IRotaryFocusable
+    public class CircleScrollView : ScrollView, IRotaryFocusable, ICircleSurfaceConsumer
     {
         /// <summary>
         /// BindableProperty. Identifies the Header, Footer cancel the Fish Eye Effect or not.
@@ -40,5 +40,11 @@ namespace Tizen.Wearable.CircularUI.Forms
             get => (Color)GetValue(BarColorProperty);
             set => SetValue(BarColorProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a CircleSurfaceProvider.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public ICircleSurfaceProvider CircleSurfaceProvider { get; set; }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleStepper.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleStepper.cs
@@ -23,7 +23,7 @@ namespace Tizen.Wearable.CircularUI.Forms
     /// The CircleStepper is a class that extends Xamarin.Forms.Stepper for Circular UI.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public class CircleStepper : Xamarin.Forms.Stepper, IRotaryFocusable
+    public class CircleStepper : Stepper, IRotaryFocusable, ICircleSurfaceConsumer
     {
         /// <summary>
         /// BindableProperty. Identifies the MarkerColor bindable property.
@@ -106,5 +106,11 @@ namespace Tizen.Wearable.CircularUI.Forms
             get => (bool)GetValue(IsWrapEnabledProperty);
             set => SetValue(IsWrapEnabledProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a CircleSurfaceProvider.
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        public ICircleSurfaceProvider CircleSurfaceProvider { get; set; }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/CircleSurfaceView.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/CircleSurfaceView.cs
@@ -16,13 +16,17 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using Xamarin.Forms;
 
 namespace Tizen.Wearable.CircularUI.Forms
 {
-    public class CircleSurfaceView : View
+    public class CircleSurfaceView : View, ICircleSurfaceProvider
     {
         public IList<ICircleSurfaceItem> CircleSurfaceItems { get; internal set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public object CircleSurface { get; set; }
 
         public CircleSurfaceView()
         {

--- a/src/Tizen.Wearable.CircularUI.Forms/ICircleSurfaceConsumer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/ICircleSurfaceConsumer.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tizen.Wearable.CircularUI.Forms
+{
+    /// <summary>
+    /// The ICircleSurfaceConsumer is an interface represents the CircleSurfaceObject.
+    /// </summary>
+    /// <since_tizen> 4 </since_tizen>
+    public interface ICircleSurfaceConsumer
+    {
+        /// <summary>
+        /// Gets or sets CircleSurfaceProvider
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        ICircleSurfaceProvider CircleSurfaceProvider { get; set; }
+    }
+}

--- a/src/Tizen.Wearable.CircularUI.Forms/ICircleSurfaceProvider.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/ICircleSurfaceProvider.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.Wearable.CircularUI.Forms
+{
+    /// <summary>
+    /// The ICircleSurfaceProvider is an interface providing the CircleSurface.
+    /// </summary>
+    /// <since_tizen> 4 </since_tizen>
+    public interface ICircleSurfaceProvider
+    {
+        /// <summary>
+        /// Gets or sets CircleSurface object. For internal use only
+        /// </summary>
+        /// <since_tizen> 4 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        object CircleSurface { get; set; }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR introduce `ICircleSurfaceProvider` and `ICircleSurfaceConsumer`. Firstly, `ICircleSurfaceProvider` is an interface for circle object provider and currently only two classes - `CirclePage` and `CircleSurfaceView` - are circle surface provider. Secondly, `ICiircleSurfaceConsumer` is an interface for circle object views that are rendered on a circle surface. Currently, there are four Circular Views rendered on a circle surface.  Those are `CircleListView`, `CircleScrollView`, `CircleStepper` and `CircleDateTimeSelector`. These circle object views should explicitly set the circle surface provider to provide them a circle surface through the `CircleSurfaceProvider` property as shown below.

```cs

// CirclePage circlePage

var circleListView = new CircleListView {
    //...
    CircleSurfaceProvider = circlePage // (or circleSurfaceView)
};
```

> **NOTE**
> Exceptionally, if consumer views belong to the content of the `CirclePage`, it will implicitly get the circle surface from the `CirclePage`. Otherwise, if you don't explicitly set the provider, it will use the [global circle surface](https://github.com/xamarin/Xamarin.Forms/issues/10083) created by platform by default. 

### Bugs Fixed ###
None

### API Changes ###
Added:
 - interface ICircleSurfaceProvider
 - interface ICircleSurfaceConsumer
 - CircleListView.CircleSurfaceProvider {get; set;}
 - CircleScrollView.CircleSurfaceProvider {get; set;}
 - CircleDateTimeSelector.CircleSurfaceProvider {get; set;}
 - CircleStepper.CircleSurfaceProvider {get; set;}

### Behavioral Changes ###
None

