### PR TITLE
Adds OverlayContent to Application

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircularUI.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircularUI.cs
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using System;
+using System.ComponentModel;
 using System.Diagnostics;
-using ElmSharp;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+using XForms = Xamarin.Forms.Forms;
 
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
 {
+    using Xamarin.Forms.PlatformConfiguration;
+
     public static class FormsCircularUI
     {
         public static readonly string Tag = "CircularUI";
@@ -43,6 +47,28 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             }
 
             Init();
+        }
+
+        public static void AddAppPropertyChangedHandler(this Application application)
+        {
+            UpdateOverlayContent();
+            application.PropertyChanged += AppOnPropertyChanged;
+        }
+
+        static void AppOnPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (ApplicationExtension.OverlayContentProperty.PropertyName == args.PropertyName)
+            {
+                UpdateOverlayContent();
+            }
+        }
+
+        static void UpdateOverlayContent()
+        {
+            var renderer = Platform.GetOrCreateRenderer(Application.Current.On<Tizen>().GetOverlayContent());
+            (renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
+            var nativeView = renderer?.NativeView;
+            XForms.BaseLayout.SetPartContent("elm.swallow.overlay", nativeView);
         }
     }
 }

--- a/src/Tizen.Wearable.CircularUI.Forms/ApplicationExtension.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms/ApplicationExtension.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+using Application = Xamarin.Forms.Application;
+using T = Xamarin.Forms.PlatformConfiguration.Tizen;
+
+namespace Tizen.Wearable.CircularUI.Forms
+{
+    public static class ApplicationExtension
+    {
+        public static readonly BindableProperty OverlayContentProperty
+            = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(Application), default(View));
+
+        public static View GetOverlayContent(BindableObject application)
+        {
+            return (View)application.GetValue(OverlayContentProperty);
+        }
+
+        public static void SetOverlayContent(BindableObject application, View value)
+        {
+            application.SetValue(OverlayContentProperty, value);
+        }
+
+        public static View GetOverlayContent(this IPlatformElementConfiguration<T, Application> config)
+        {
+            return GetOverlayContent(config.Element);
+        }
+
+        public static IPlatformElementConfiguration<T, Application> SetOverlayContent(this IPlatformElementConfiguration<T, Application> config, View value)
+        {
+            SetOverlayContent(config.Element, value);
+            return config;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR is about overlay content view of application. Some application want to use overlay content view that is a view for hosting layered content on top of the application view. (e.g. Floating Button)
To support this, this PR adds a Tizen Specific API. 

> Currently, it exists temporarily in the dev branch in CircularUI repository, but will be applied in Xamarin.Forms upstream repository later.

#### Developer Guide ####
This Tizen platform-specific is used to host layered content on top of the application. It's consumed in XAML by setting the `Application.OverlayContent` bindable property.

```xml
<Application ...
              xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms">
    <w:Application.OverlayContent>
         <StackLayout InputTransparent="True" CascadeInputTransparent="False"> 
            <Button Text="Floating Button 1"/>
            <Button Text="Floating Button 2"/>
        </StackLayout>
    </w:Application.OverlayContent>
</Application>
```

> **Important**
> The `OverlayContent` occupies the entire screen and can be composed of single view or multiple views views using layout. When using `OverlayContent`, you should take special care of event management through `VisualElement.InputTransparent` and  `VisualElement.CascadeInputTransparent`  because all user input is taken from the `OverlayContent`.

Alternatively, it can be consumed from C# using the fluent API:

```cs
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
...

Application.Current.On<Tizen>()
.SetOverlayContent( new StackLayout {
                InputTransparent = true,
                CascadeInputTransparent = false,
                Children =
                {
                    new Button { Text ="Floating Button 1"},
                    new Button { Text ="Floating Button 2"},
                }
            });
```

> **Limitation**
>We recommend that you do not overlap `OverlayContent` that receives user input on views that also receive user input (e.g. `Button`). If you place them nested like this, user input (e.g. click) is passed to all views, including `OverlayContent` views due to platform constraint.

Finally, in order to use `OverlayContent` with CircularUI, you need to add an Application's property changed event handler as follows. This step will be removed if this change is applied to Xamarin.Forms upstream.

```cs
protected override void OnCreate()
{
        base.OnCreate();
        var app = new App();
        app.AddAppPropertyChangedHandler();
        LoadApplication(app);
}

```

### Bugs Fixed ###
None

### API Changes ###

```namespace Tizen.Wearable.CircularUI.Forms```
(will be moved to ```namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific```)

Added:
 - View Application.OverlayContent // BindableProperty 

```namespace Tizen.Wearable.CircularUI.Forms.Renderer```
( will be removed when it merged into upstream )

Added:
 - static void Application.AddAppPropertyChangedHandler() 


### Behavioral Changes ###
None
