### PR TITLE
Fix year label issue in CircleDateTimeSelector

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleDateTimeSelectorRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CircleDateTimeSelectorRenderer.cs
@@ -105,6 +105,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
                 if (Element.ValueType == DateTimeType.Date)
                 {
                     Control.Style = "datepicker/circle";
+                    Control.Format = "%d/%b/%Y";
                 }
                 else if (Element.ValueType == DateTimeType.Time)
                 {


### PR DESCRIPTION
### Description of Change ###
Fix year label issue in CircleDateTimeSelector in latest Tizen 5.5 SPIN binary.
Format was not applied when ValueType is DateTimeType.Date.


### Bugs Fixed ###
Fix issue https://github.com/Samsung/Tizen.CircularUI/issues/267

[before]
![image](https://user-images.githubusercontent.com/31116585/78953883-41ff4700-7b15-11ea-866b-4d86b4307d6a.png)

[after]
![dump_screen](https://user-images.githubusercontent.com/31116585/78954111-0b75fc00-7b16-11ea-8f26-ee18fc5e1283.png)


### API Changes ###
None


### Behavioral Changes ###
None

