### PR TITLE
Make PageRenderer even better

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PageRenderer.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+using Xamarin.Forms.Platform.Tizen.Native.Watch;
+using XPageRenderer = Xamarin.Forms.Platform.Tizen.PageRenderer;
+using CPageRenderer = Tizen.Wearable.CircularUI.Forms.Renderer.PageRenderer;
+
+[assembly: ExportRenderer(typeof(Page), typeof(CPageRenderer))]
+namespace Tizen.Wearable.CircularUI.Forms.Renderer
+{
+    public class PageRenderer : XPageRenderer
+    {
+        protected override FormsMoreOptionItem CreateMoreOptionItem(ToolbarItem item)
+        {
+            var moreOptionItem = base.CreateMoreOptionItem(item);
+            if (item is CircleToolbarItem circleToolbarItem)
+            {
+                moreOptionItem.SubText = circleToolbarItem.SubText;
+            }
+            return moreOptionItem;
+        }
+    }
+}

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleSurfaceView.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleSurfaceView.xaml
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="WearableUIGallery.TC.TCCircleSurfaceView"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:WearableUIGallery.TC"
+    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms">
+    <ContentPage.Content>
+        <AbsoluteLayout BackgroundColor="Black" x:Name="RootView">
+            <w:CircleSurfaceView AbsoluteLayout.LayoutBounds="0,0,1,1" AbsoluteLayout.LayoutFlags="All" InputTransparent="True">
+                <w:CircleSurfaceView.CircleSurfaceItems>
+                    <w:CircleProgressBarSurfaceItem x:Name="progress1" Value="1" />
+                    <w:CircleProgressBarSurfaceItem
+                        BackgroundColor="Green"
+                        BackgroundLineWidth="20"
+                        BackgroundRadius="90"
+                        BarColor="Red"
+                        BarLineWidth="15"
+                        BarRadius="90"
+                        Value="0.5" />
+                    <w:CircleSliderSurfaceItem
+                        x:Name="AlertSlider"
+                        BackgroundColor="Green"
+                        BackgroundLineWidth="20"
+                        BackgroundRadius="150"
+                        BarColor="SkyBlue"
+                        BarLineWidth="15"
+                        BarRadius="150"
+                        Increment="2"
+                        Maximum="20"
+                        Minimum="0"
+                        Value="10" />
+                    <w:CircleSliderSurfaceItem
+                        x:Name="RingtoneSlider"
+                        Increment="1"
+                        Maximum="15"
+                        Minimum="0"
+                        Value="8" />
+                </w:CircleSurfaceView.CircleSurfaceItems>
+            </w:CircleSurfaceView>
+        </AbsoluteLayout>
+    </ContentPage.Content>
+    <ContentPage.ToolbarItems>
+        <ToolbarItem
+            x:Name="ToolbarItem"
+            Icon="image/tizen.png"
+            Text="MainText"/>
+        <w:CircleToolbarItem
+            x:Name="CircleToolbarItem"
+            Icon="image/tizen.png"
+            Text="MainText"
+            SubText="SubText"/>
+    </ContentPage.ToolbarItems>
+</ContentPage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleSurfaceView.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleSurfaceView.xaml.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace WearableUIGallery.TC
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TCCircleSurfaceView : ContentPage
+    {
+        public TCCircleSurfaceView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/test/WearableUIGallery/WearableUIGallery/TCData.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TCData.cs
@@ -27,6 +27,7 @@ namespace WearableUIGallery
         {
             TCs = new ObservableCollection<TCDescribe>();
             TCs.Add(new TCDescribe { Title = "ContentButtonTest", Class = typeof(ContentButtonTestPage) });
+            TCs.Add(new TCDescribe { Title = "CircleSurfaceView", Class = typeof(TCCircleSurfaceView) });
             TCs.Add(new TCDescribe
             {
                 Title = "ShellTest",

--- a/test/WearableUIGallery/WearableUIGallery/WearableUIGallery.csproj
+++ b/test/WearableUIGallery/WearableUIGallery/WearableUIGallery.csproj
@@ -15,6 +15,11 @@
     <ProjectReference Include="..\..\..\src\Tizen.Wearable.CircularUI.Forms\Tizen.Wearable.CircularUI.Forms.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="TC\TCCircleSurfaceView.xaml.cs">
+      <DependentUpon>TCCircleSurfaceView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="TC\TCRadialProgress.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###
This PR improve existing `Page` to support not only `ToolbarItem` but also `CircleToolbarItem`.
We sometimes need sub text in `MoreOption`. For this, `CircleToolbarItem` was provided by CircularUI, and it could only be used in `CirclePage`. From now on, with this PR, it can be used in any Page (e.g. `ContentPage`)

```xml
<ContentPage ...
    xmlns:w="clr-namespace:Tizen.Wearable.CircularUI.Forms;assembly=Tizen.Wearable.CircularUI.Forms">
<ContentPage.ToolbarItems>
        <ToolbarItem
            Icon="image/tizen.png"
            Text="MainText"/>
        <w:CircleToolbarItem
            Icon="image/tizen.png"
            Text="MainText"
            SubText="SubText"/>
</ContentPage.ToolbarItems>
...
```

The result:
- **ToolbarItem**
<img src="https://user-images.githubusercontent.com/1029134/79844042-196d2c00-83f6-11ea-86e6-24b33b8e5d4b.png" width=240/>

- **CircleToobarItem**
<img src="https://user-images.githubusercontent.com/1029134/79844051-1b36ef80-83f6-11ea-9efd-dba278f8a6df.png" width=240/>

### Bugs Fixed ###
None

### API Changes ###
None

### Behavioral Changes ###
None.