### PR TITLE
Fix rotary event activation issue

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/CirclePageRenderer.cs
@@ -427,6 +427,9 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
 
         void ActivateRotaryWidget()
         {
+            if (!Element.Appeared)
+                return;
+
             if (_currentRotaryFocusObject is IRotaryEventReceiver)
             {
                 ERotaryEventManager.Rotated += OnRotaryEventChanged;

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCirclePage.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCirclePage.xaml
@@ -100,5 +100,9 @@
             x:Name="ChangeName"
             Icon="image/question.png"
             Text="MainText"/>
+        <w:CircleToolbarItem
+            Clicked="CircleToolbarItem_Clicked"
+            Icon="image/question.png"
+            Text="Popup"/>
     </w:CirclePage.ToolbarItems>
 </w:CirclePage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCirclePage.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCirclePage.xaml.cs
@@ -29,5 +29,10 @@ namespace WearableUIGallery.TC
 
             ChangeName.SubText = "SubText";
         }
+
+        void CircleToolbarItem_Clicked(object sender, System.EventArgs e)
+        {
+            Navigation.PushModalAsync(new TCCircleScroller());
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###
When ToolbarItems was open and closed, rotary event on CirclePage was activating even though disappeared page so rotary event was stolen by it
So fix it, If page was not appeared, didn't activation rotary event

### Bugs Fixed ###
- Rotary event was not delivered, on newly opened page by ToolbarItem handler


### API Changes ###
None

### Behavioral Changes ###
None
