### PR TITLE
Enhance the Page renderer

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PageRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PageRenderer.cs
@@ -14,25 +14,210 @@
  * limitations under the License.
  */
 
+using System;
+using ElmSharp.Wearable;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using Xamarin.Forms.Platform.Tizen.Native.Watch;
 using XPageRenderer = Xamarin.Forms.Platform.Tizen.PageRenderer;
 using CPageRenderer = Tizen.Wearable.CircularUI.Forms.Renderer.PageRenderer;
+using EColor = ElmSharp.Color;
+using NPage = Xamarin.Forms.Platform.Tizen.Native.Page;
+using NLayoutEventArgs = Xamarin.Forms.Platform.Tizen.Native.LayoutEventArgs;
+using XForms = Xamarin.Forms.Forms;
+using System.Collections.Specialized;
 
 [assembly: ExportRenderer(typeof(Page), typeof(CPageRenderer))]
 namespace Tizen.Wearable.CircularUI.Forms.Renderer
 {
-    public class PageRenderer : XPageRenderer
-    {
-        protected override FormsMoreOptionItem CreateMoreOptionItem(ToolbarItem item)
-        {
-            var moreOptionItem = base.CreateMoreOptionItem(item);
-            if (item is CircleToolbarItem circleToolbarItem)
-            {
-                moreOptionItem.SubText = circleToolbarItem.SubText;
-            }
-            return moreOptionItem;
-        }
-    }
+	// TODO: need to change the implementation to inhert the PageRenderer later
+	public class PageRenderer : VisualElementRenderer<Page>
+	{
+		NPage _page;
+		Lazy<MoreOption> _moreOption;
+
+		public PageRenderer()
+		{
+			RegisterPropertyHandler(Page.BackgroundImageSourceProperty, UpdateBackgroundImage);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
+		{
+			if (null == _page)
+			{
+				_page = new NPage(XForms.NativeParent);
+				_page.LayoutUpdated += OnLayoutUpdated;
+				SetNativeView(_page);
+			}
+			base.OnElementChanged(e);
+		}
+
+		protected override void OnElementReady()
+		{
+			_moreOption = new Lazy<MoreOption>(CreateMoreOption);
+			if (Element.ToolbarItems is INotifyCollectionChanged items)
+			{
+				items.CollectionChanged += OnToolbarCollectionChanged;
+			}
+			if (Element.ToolbarItems.Count > 0)
+			{
+				UpdateToolbarItems(true);
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				if (_page != null)
+				{
+					_page.LayoutUpdated -= OnLayoutUpdated;
+				}
+
+				if (Element.ToolbarItems is INotifyCollectionChanged items)
+				{
+					items.CollectionChanged -= OnToolbarCollectionChanged;
+				}
+
+				if (_moreOption.IsValueCreated)
+				{
+					_moreOption.Value.Clicked -= OnMoreOptionItemClicked;
+					_moreOption.Value.Closed -= SendMoreOptionClosed;
+					_moreOption.Value.Opened -= SendMoreOptionOpened;
+					_moreOption.Value.Items.Clear();
+					_moreOption.Value.Unrealize();
+				}
+			}
+			base.Dispose(disposing);
+		}
+
+		protected override void UpdateBackgroundColor(bool initialize)
+		{
+			if (initialize && Element.BackgroundColor.IsDefault)
+				return;
+
+			// base.UpdateBackgroundColor() is not called on purpose, we don't want the regular background setting
+			if (Element.BackgroundColor.IsDefault || Element.BackgroundColor.A == 0)
+				_page.Color = EColor.Transparent;
+			else
+				_page.Color = Element.BackgroundColor.ToNative();
+		}
+
+		protected override void UpdateLayout()
+		{
+			// empty on purpose
+		}
+
+		protected virtual FormsMoreOptionItem CreateMoreOptionItem(ToolbarItem item)
+		{
+			var moreOptionItem = new FormsMoreOptionItem
+			{
+				MainText = item.Text,
+				ToolbarItem = item
+			};
+			var icon = item.IconImageSource as FileImageSource;
+			if (icon != null)
+			{
+				var img = new ElmSharp.Image(_moreOption.Value);
+				img.Load(ResourcePath.GetPath(icon));
+				moreOptionItem.Icon = img;
+			}
+			if (item is CircleToolbarItem circleToolbarItem)
+			{
+				moreOptionItem.SubText = circleToolbarItem.SubText;
+			}
+			return moreOptionItem;
+		}
+
+		protected virtual void OnMoreOptionClosed()
+		{
+		}
+
+		protected virtual void OnMoreOptionOpened()
+		{
+		}
+
+		void UpdateBackgroundImage(bool initialize)
+		{
+			if (initialize && Element.BackgroundImageSource.IsNullOrEmpty())
+				return;
+
+			// TODO: investigate if we can use the other image source types: stream, font, uri
+
+			var bgImage = Element.BackgroundImageSource as FileImageSource;
+			if (bgImage.IsNullOrEmpty())
+				_page.File = null;
+			else
+				_page.File = ResourcePath.GetPath(bgImage);
+		}
+
+		void OnLayoutUpdated(object sender, NLayoutEventArgs e)
+		{
+			Element.Layout(e.Geometry.ToDP());
+
+			if (_moreOption != null && _moreOption.IsValueCreated)
+			{
+				_moreOption.Value.Geometry = _page.Geometry;
+			}
+		}
+
+		MoreOption CreateMoreOption()
+		{
+			var moreOption = new MoreOption(_page);
+			moreOption.Geometry = _page.Geometry;
+			_page.Children.Add(moreOption);
+			moreOption.Show();
+			moreOption.Clicked += OnMoreOptionItemClicked;
+			moreOption.Closed += SendMoreOptionClosed;
+			moreOption.Opened += SendMoreOptionOpened;
+			return moreOption;
+		}
+
+		void SendMoreOptionClosed(object sender, EventArgs e)
+		{
+			OnMoreOptionClosed();
+		}
+
+		void SendMoreOptionOpened(object sender, EventArgs e)
+		{
+			OnMoreOptionOpened();
+		}
+
+		void OnToolbarCollectionChanged(object sender, EventArgs eventArgs)
+		{
+				UpdateToolbarItems(false);
+		}
+
+		void UpdateToolbarItems(bool initialize)
+		{
+			//clear existing more option items and add toolbar item again on purpose.
+			if (!initialize && _moreOption.Value.Items.Count > 0)
+			{
+				_moreOption.Value.Items.Clear();
+			}
+
+			if (Element.ToolbarItems.Count > 0)
+			{
+				_moreOption.Value.Show();
+				foreach (var item in Element.ToolbarItems)
+				{
+					_moreOption.Value.Items.Add(CreateMoreOptionItem(item));
+				}
+			}
+			else
+			{
+				_moreOption.Value.Hide();
+			}
+		}
+
+		void OnMoreOptionItemClicked(object sender, MoreOptionItemEventArgs e)
+		{
+			var formsMoreOptionItem = e.Item as FormsMoreOptionItem;
+			if (formsMoreOptionItem != null)
+			{
+				((IMenuItemController)formsMoreOptionItem.ToolbarItem)?.Activate();
+			}
+			_moreOption.Value.IsOpened = false;
+		}
+	}
 }

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleToolbarItem.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleToolbarItem.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="WearableUIGallery.TC.TCCircleToolbarItem"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <ContentPage.Content>
+        <StackLayout
+            BackgroundColor="Black"
+            HorizontalOptions="CenterAndExpand"
+            Orientation="Vertical"
+            VerticalOptions="CenterAndExpand">
+            <Button x:Name="addButton"
+                    Text="Add ToolbarItem"
+                    AutomationId="add"
+                    VerticalOptions="CenterAndExpand"
+                    HorizontalOptions="CenterAndExpand"
+                    Clicked="OnItemAddClicked"/>
+            <Button x:Name="removeButton"
+                    Text="Remove ToolbarItem"
+                    AutomationId="remove"
+                    VerticalOptions="CenterAndExpand"
+                    HorizontalOptions="CenterAndExpand"
+                    Clicked="OnItemRemoveClicked"/>
+            <Label x:Name="cntLabel"
+                   AutomationId="label"
+                   VerticalOptions="CenterAndExpand"
+                   HorizontalOptions="CenterAndExpand"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCCircleToolbarItem.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCCircleToolbarItem.xaml.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+using Tizen.Wearable.CircularUI.Forms;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+
+namespace WearableUIGallery.TC
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TCCircleToolbarItem : ContentPage
+    {
+        public TCCircleToolbarItem()
+        {
+            InitializeComponent();
+            cntLabel.Text = "# of items :"+ ToolbarItems.Count;
+        }
+
+        void OnItemAddClicked(object sender, System.EventArgs e)
+        {
+            AddToolbarItem("ToolbarItem", "ID :" + ToolbarItems.Count, "image/icon_alert_sound.png");
+        }
+
+        void OnItemRemoveClicked(object sender, System.EventArgs e)
+        {
+            RemoveToolbarItem();
+        }
+
+        void AddToolbarItem(string mainText, string subText, string icon)
+        {
+            CircleToolbarItem item = new CircleToolbarItem
+            {
+                Text = mainText,
+                SubText = subText,
+                IconImageSource = icon
+            };
+            ToolbarItems.Add(item);
+            cntLabel.Text = "# of items :" + ToolbarItems.Count;
+        }
+
+        void RemoveToolbarItem()
+        {
+            var id = ToolbarItems.Count - 1;
+            if (id < 0)
+                return;
+            ToolbarItems.RemoveAt(id);
+            cntLabel.Text = "# of items :" + ToolbarItems.Count;
+        }
+    }
+}

--- a/test/WearableUIGallery/WearableUIGallery/TCData.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TCData.cs
@@ -71,6 +71,8 @@ namespace WearableUIGallery
             });
             TCs.Add(new TCDescribe { Title = "BezelInteraction", Class = typeof(TCBezelInteractionPage) });
             TCs.Add(new TCDescribe { Title = "DateTimeSelector", Class = typeof(TCCircleDateTimeSelector) });
+            TCs.Add(new TCDescribe { Title = "BottomButton", Class = typeof(TCActionButton) });
+            TCs.Add(new TCDescribe { Title = "CircleToolbarItem", Class = typeof(TCCircleToolbarItem) });
             TCs.Add(new TCDescribe
             {
                 Title = "CircleSurfaceItem",

--- a/test/WearableUIGallery/WearableUIGallery/WearableUIGallery.csproj
+++ b/test/WearableUIGallery/WearableUIGallery/WearableUIGallery.csproj
@@ -15,6 +15,9 @@
     <ProjectReference Include="..\..\..\src\Tizen.Wearable.CircularUI.Forms\Tizen.Wearable.CircularUI.Forms.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="TC\TCCircleToolbarItem.xaml.cs">
+      <DependentUpon>TCCircleToolbarItem.xaml</DependentUpon>
+    </Compile>
     <Compile Update="TC\TCSingleTextCell.xaml.cs">
       <DependentUpon>TCSingleTextCell.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
### Description of Change ###
This is a fix to support adding/deleting page toolbar items at runtime.

<img src="https://user-images.githubusercontent.com/1029134/84459572-c0f23680-aca2-11ea-818c-2269852d1ab1.gif" width=240/>

I've temporarily moved the Xamarin.Forms.PageRenderer implementation to support this feature in CircularUI even before a new package of Xamarin.Forms is published. When a new Xamarin.Forms package with a [patch ](https://github.com/xamarin/Xamarin.Forms/pull/11015)enabling it is published, it will be changed to inherit PageRenderer again.

### Bugs Fixed ###
 None

### API Changes ###
None


