### PR TITLE
Fix the MaxLengh of the PopupEntry

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/PopupEntryRenderer.cs
@@ -22,6 +22,7 @@ using Xamarin.Forms.Platform.Tizen;
 using Xamarin.Forms.Platform.Tizen.Native;
 using EColor = ElmSharp.Color;
 using ELayout = ElmSharp.Layout;
+using EEntry = ElmSharp.Entry;
 using XForms = Xamarin.Forms.Forms;
 using XEntry = Xamarin.Forms.Entry;
 
@@ -128,6 +129,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             _editor.Scrollable = true;
             _editor.SetInputPanelEnabled(false);
             _editor.AllowFocus(true);
+            _editor.PrependMarkUpFilter(PopupEntryMaxLengthFilter);
             _editor.Show();
 
             _editor.SetInputPanelReturnKeyType(Element.ReturnType.ToInputPanelReturnKeyType());
@@ -154,6 +156,14 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         void PopupEntryActivated(object sender, EventArgs e)
         {
             ((IEntryController)Element).SendCompleted();
+        }
+
+        string PopupEntryMaxLengthFilter(EEntry entry, string s)
+        {
+            if (entry.Text.Length < Element.MaxLength)
+                return s;
+
+            return null;
         }
 
         void HidePopup()

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCPopupEntry.xaml
@@ -15,10 +15,11 @@
                     BackgroundColor="Gray"
                     HorizontalOptions="FillAndExpand"
                     TextColor="Blue"
-                    Placeholder="Foobar"
+                    Placeholder="Max Lenth=4"
                     PlaceholderColor="Blue"
                     VerticalOptions="CenterAndExpand"
                     ReturnType="Search"
+                    MaxLength="4"
                     x:Name="PopupEntry1"/>
                 <w:PopupEntry
                     AutomationId="popupEntry2"


### PR DESCRIPTION
### Description of Change ###
Fix the max lengh of the PopupEntry correctly.

- **TCPopupEntry** (MaxLength=4)
<img src="https://user-images.githubusercontent.com/1029134/95030141-7d578880-06e8-11eb-924e-3096335afd65.gif" width="320"/>

### Bugs Fixed ###
- fixes #340


### API Changes ###
None

### Behavioral Changes ###
None