### PR TITLE
Fix MediaPlayer issue

### DIFF
--- a/src/Tizen.Wearable.CircularUI.Forms.Renderer/MediaPlayerImpl.cs
+++ b/src/Tizen.Wearable.CircularUI.Forms.Renderer/MediaPlayerImpl.cs
@@ -184,7 +184,7 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
         {
             try
             {
-                await _player.SetPlayPositionAsync(ms, false);
+                await _player.SetPlayPositionAsync(ms, true);
             }
             catch (Exception e)
             {
@@ -275,13 +275,16 @@ namespace Tizen.Wearable.CircularUI.Forms.Renderer
             await handler.SetSource(_player, _source);
         }
 
-        async void OnTargetViewPropertyChanged(object sender, global::System.ComponentModel.PropertyChangedEventArgs e)
+        void OnTargetViewPropertyChanged(object sender, global::System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "Renderer")
             {
                 if (Platform.GetRenderer(sender as BindableObject) != null && HasSource && AutoPlay)
                 {
-                    await Start();
+                    Device.BeginInvokeOnMainThread(() =>
+                    {
+                        _ = Start();
+                    });
                 }
                 else if (Platform.GetRenderer(sender as BindableObject) == null && AutoStop)
                 {

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCMediaViewStackLayout.xaml
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCMediaViewStackLayout.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage
+<w:BezelInteractionPage
     x:Class="WearableUIGallery.TC.TCMediaViewStackLayout"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -11,4 +11,4 @@
             </w:MediaView>
         </StackLayout>
     </ContentPage.Content>
-</ContentPage>
+</w:BezelInteractionPage>

--- a/test/WearableUIGallery/WearableUIGallery/TC/TCMediaViewStackLayout.xaml.cs
+++ b/test/WearableUIGallery/WearableUIGallery/TC/TCMediaViewStackLayout.xaml.cs
@@ -13,17 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Xamarin.Forms;
+using Tizen.Wearable.CircularUI.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace WearableUIGallery.TC
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class TCMediaViewStackLayout : ContentPage
+    public partial class TCMediaViewStackLayout : BezelInteractionPage, IRotaryEventReceiver
     {
         public TCMediaViewStackLayout()
         {
             InitializeComponent ();
+            RotaryFocusObject = this;
+        }
+
+        public void Rotate(RotaryEventArgs args)
+        {
+            if (args.IsClockwise)
+            {
+                VideoPlayer.Seek(VideoPlayer.Position + 2000);
+            }
+            else
+            {
+                VideoPlayer.Seek(VideoPlayer.Position - 2000);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
 This PR fixes several media player issue
 - When Renderer was created and AutoPlay is enabled, start media play on next rendering loop, it solve video rendering issue
 - Use TizenFX Media Seek API with accurate option, it can seek on non key frame

### Bugs Fixed ###
 - Video was not rendered on MediaView if started when window size was not determined, it fixed
 - Fixes: #358 (MediaPlayer Seek was not working if key frame was not existed on seeking boundary, it fixed)

### API Changes ###
None

### Behavioral Changes ###
Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

